### PR TITLE
Update installation docs

### DIFF
--- a/docs/LitTools/JSSDK/installation.md
+++ b/docs/LitTools/JSSDK/installation.md
@@ -2,6 +2,9 @@
 sidebar_position: 2
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Installation
 
 Use yarn or npm to add the lit-js-sdk to your product:
@@ -11,67 +14,97 @@ yarn add lit-js-sdk
 ```
 
 ## Importing
+### For the browser
 
-### For the browser, imported
+<Tabs
+    defaultValue="imported"
+    values={[
+        {label: 'imported', value: 'imported'},
+        {label: 'script tag', value: 'script-tag'},
+    ]}>
+<TabItem value="imported">
 
-```
-import LitJsSdk from 'lit-js-sdk'
-```
+    import LitJsSdk from 'lit-js-sdk'
 
-### For the browser, as a script tag
+</TabItem>
+<TabItem value="script-tag">
 
-We also provide a web-ready package with all dependencies included at build/index.web.js. You can import this into your HTML webpage using a script tag:
+    <script onload='LitJsSdk.litJsSdkLoadedInALIT()' src="https://jscdn.litgateway.com/index.web.js"></script>
 
-```
-<script onload='LitJsSdk.litJsSdkLoadedInALIT()' src="https://jscdn.litgateway.com/index.web.js"></script>
-```
+</TabItem>
+</Tabs>
 
-You can then use all the sdk functions via LitJsSdk for example `LitJsSdk.toggleLock()`
+If you decide to import the SDK with the script tag, we provide a web-ready package with all dependencies included at build/index.web.js. 
+You can use all the SDK functions via LitJsSdk, for example `LitJsSdk.toggleLock()`
 
 ### For the server side (NodeJS), imported
-
-Note: You should use at least Node v16 because of the need for the webcrypto library.  
-You can use Node v14 (and possibly lower) if you import a global webcrypto polyfill like @peculiar/webcrypto and define the global `crypto` object in your code.
 
 ```
 import LitJsSdk from 'lit-js-sdk/build/index.node.js'
 ```
+**Note**: You should use at least Node v16 because of the need for the webcrypto library.  
+You can use Node v14 (and possibly lower) if you import a global webcrypto polyfill like @peculiar/webcrypto and define the global `crypto` object in your code.
 
 ## Connection to the Lit Network
 
-The SDK requires an active connection to the LIT nodes to perform most functions (but, notably, a connection to the LIT nodes is not required if you are just verifying a JWT). In web apps, this is typically done on first page load and can be shared between all your pages. In NodeJS apps, this is done when when the server starts.
+The SDK requires an active connection to the LIT nodes to perform most functions (notably, a connection to the LIT nodes is not required if you are just verifying a JWT). In web apps, this is typically done on first page load and can be shared between all your pages. In NodeJS apps, this is done when when the server starts.
 
-### SDK installed via yarn / NPM (browser usage)
+### SDK installed via yarn or the script tag (browser usage)
+ <Tabs
+    defaultValue="yarn"
+    values={[
+        {label: 'yarn / NPM', value: 'yarn'},
+        {label: 'script tag', value: 'script'},
+    ]}>
+<TabItem value="yarn">
 
-To connect, use the code below. Note that client.connect() will return a promise that resolves when you are connected to the Lit Network. You may also listen for the `lit-ready` event. In the code below, we make the litNodeClient available as a global variable so that it can be used throughout the web app.
+    const client = new LitJsSdk.LitNodeClient()
+    await client.connect()
+    window.litNodeClient = client
 
-```
-const client = new LitJsSdk.LitNodeClient()
-await client.connect()
-window.litNodeClient = client
-```
+</TabItem>
+<TabItem value="script">
 
-### SDK installed via the script tag (browser usage)
+    function litJsSdkLoaded(){
+      var litNodeClient = new LitJsSdk.LitNodeClient()
+      litNodeClient.connect()
+      window.litNodeClient = litNodeClient
+    }
+</TabItem>
+</Tabs>
+
+In the **yarn / NPM** example: 
+
+Note that client.connect() will return a promise that resolves when you are connected to the Lit Network. You may also listen for the `lit-ready` event. In the code below, we make the litNodeClient available as a global variable so that it can be used throughout the web app.
+
+In the **script tag** example:
 
 If you're using the script tag with `onload='litJsSdkLoaded()'` then you can put the connection code in the `litJsSdkLoaded()` function.
 
-```
-function litJsSdkLoaded(){
-  var litNodeClient = new LitJsSdk.LitNodeClient()
-  litNodeClient.connect()
-  window.litNodeClient = litNodeClient
-}
-```
-
 ### SDK installed via yarn / NPM (NodeJS / serverside usage)
-
-To connect, use the code below. Note that client.connect() will return a promise that resolves when you are connected to the Lit Network. In this example, we store the litNodeClient in a global variable `app.locals.litNodeClient` so that it can be used throughout the server. `app.locals` is provided by Express for this purpose. You may have to use whatever your own server framework provides for this purpose, instead.
+In this example, we store the litNodeClient in a global variable `app.locals.litNodeClient` so that it can be used throughout the server. `app.locals` is provided by Express for this purpose. You may have to use what your own server framework provides for this purpose, instead.
 
 ```
 app.locals.litNodeClient = new LitJsSdk.LitNodeClient({
   alertWhenUnauthorized: false,
-});
-await app.locals.litNodeClient.connect();
+})
+await app.locals.litNodeClient.connect()
+```
+**Note** that client.connect() will return a promise that resolves when you are connected to the Lit Network.
+
+### SDK installed via yarn / NPM (client side usage)
+
+```
+const client = new LitJsSdk.LitNodeClient()
+
+class Lit {
+  private litNodeClient
+  async connect() {
+    await client.connect()
+    this.litNodeClient = client
+  }
+}
+export default new Lit()
 ```
 
 ## Listening for the lit-ready event

--- a/docs/LitTools/JSSDK/installation.md
+++ b/docs/LitTools/JSSDK/installation.md
@@ -93,6 +93,7 @@ await app.locals.litNodeClient.connect()
 **Note** that client.connect() will return a promise that resolves when you are connected to the Lit Network.
 
 ### SDK installed via yarn / NPM (client side usage)
+Within a file (we like to call ours `lit.js`), set up your Lit object.
 
 ```
 const client = new LitJsSdk.LitNodeClient()

--- a/docs/supportedChains.md
+++ b/docs/supportedChains.md
@@ -21,7 +21,6 @@ Don't see a blockchain you want?  Email support@litprotocol.com to request that 
 - Cronos
 - Optimism
 - Celo
-- Aurora
 - Solana
 - SolanaDevnet
 - SolanaTestnet


### PR DESCRIPTION
Create clear docs on how to install Lit, with an example of how to install Lit on the client-side.

Previous:
<img width="1338" alt="Screen Shot 2022-06-01 at 5 23 47 PM" src="https://user-images.githubusercontent.com/5404516/171522744-966b22d4-2f20-41bd-a0d4-d2fe0ba1730d.png">

With Changes:
<img width="1344" alt="Screen Shot 2022-06-01 at 5 22 46 PM" src="https://user-images.githubusercontent.com/5404516/171522765-34187967-ff13-4525-aabd-08188e340a8e.png">
<img width="784" alt="Screen Shot 2022-06-01 at 5 29 03 PM" src="https://user-images.githubusercontent.com/5404516/171523086-a100adc6-92b6-4a0f-a6e6-33fc63b69476.png">


Additions:
Tabs for code: this shortens the page length and allows someone to find the information they are looking for. 
Client side example: shows a non-browser or server side example of integrating lit.