### PR TITLE
feat: tool to auto-fetch repo readme

### DIFF
--- a/docs/ToolsAndExamples/Tools/getlitCli.md
+++ b/docs/ToolsAndExamples/Tools/getlitCli.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 5
+---
+
+# GetLit CLI
+
+![](https://raw.githubusercontent.com/LIT-Protocol/getlit/main/banner.png)
+
+The GetLit CLI is a command-line tool designed to help developers manage their Lit Actions projects. The CLI provides a set of commands to create, build, test, and configure Lit Actions.
+
+## Getting Started
+
+```
+npm install -g getlit
+
+// or
+yarn add global getlit
+```
+
+| Command                  | Usage                               | Description                               |
+| ------------------------ | ----------------------------------- | ----------------------------------------- |
+| `getlit init` \| `here` | `getlit init`                       | 🏁 Initialise a new Lit project           |
+| `getlit build`           | `getlit build`                      | 🏗  Build your Lit Actions                |
+| `getlit new` \| `action` | `getlit new [<lit-action-name>]` | 📝 Create a new Lit Action                |
+| `getlit test`            | `getlit test [<lit-action-name>]`   | 🧪 Test a Lit Action                      |
+| `getlit watch`           | `getlit watch [<lit-action-name>]`  | 🔧 Simultaneously build and test a Lit Action |
+| `getlit setup`           | `getlit setup`                      | 🔑 Setup config for authSig and PKP      |
+| `getlit docs` \| `doc` | `getlit docs`                       | 📖 Open the Lit Protocol documentation   |
+| `getlit help` \|  `show` | `help`    | 🆘 Show the help menu                     |
+
+## Usage
+
+To use the GetLit CLI, simply run the desired command followed by any required or optional arguments. The CLI will execute the associated function and display the output accordingly.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "update-chains": "node updateChains.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "tools": "node tools.mjs"
   },
   "dependencies": {
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",

--- a/repos.config.json
+++ b/repos.config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "sidebarPosition": 5,
+    "copyFrom": "https://raw.githubusercontent.com/LIT-Protocol/getlit/main/README.md",
+    "pasteTo": "/docs/ToolsAndExamples/Tools/getlitCli.md"
+  }
+]

--- a/tools.mjs
+++ b/tools.mjs
@@ -1,0 +1,188 @@
+import fs from "fs";
+
+const args = process.argv.slice(2);
+
+function redLog(msg, noDash = false) {
+  if (noDash) {
+    console.log("\x1b[31m%s\x1b[0m", `- ${msg}`);
+  } else {
+    console.log("\x1b[31m%s\x1b[0m", msg);
+  }
+}
+
+function greenLog(msg, noDash = false) {
+  if (noDash) {
+    console.log("\x1b[32m%s\x1b[0m", `- ${msg}`);
+  } else {
+    console.log("\x1b[32m%s\x1b[0m", msg);
+  }
+}
+
+function usageLog({ usage, options }) {
+  const optionsStr = options.map((option) => {
+    return `    <${option.name}>  ${option.description}`;
+  });
+
+  greenLog(`
+  Usage: ${usage} [options]
+  
+  Options:
+  
+    ${optionsStr}
+    
+      `);
+}
+
+async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+}
+
+try {
+  Array.prototype.asyncForEach = async function (callback) {
+    for (let index = 0; index < this.length; index++) {
+      await callback(this[index], index, this);
+    }
+  };
+} catch (e) {
+  // swallow
+}
+
+// create map of options
+const commandMaps = [
+  {
+    cmd: "pull",
+    usage: "yarn tools pull",
+    description: "pull the changes based on repo.config.js",
+    fn: pullFunc,
+  },
+];
+
+function getCmd() {
+  let cmd;
+  let errMsg = `\n❌ Command "${args[0]}" not found.\n`;
+
+  function printAllCommands() {
+    greenLog("All available commands: \n");
+    commandMaps.forEach((cm) => {
+      greenLog(`  ${cm.cmd} - ${cm.description}`);
+    });
+    greenLog(``);
+  }
+  try {
+    cmd = commandMaps.find((cm) => cm.cmd === args[0]);
+  } catch (e) {
+    redLog(errMsg);
+    printAllCommands();
+    process.exit();
+  }
+
+  if (!cmd) {
+    redLog(errMsg);
+    printAllCommands();
+    process.exit();
+  }
+
+  return cmd;
+}
+
+async function getReposConfig() {
+  const fileName = "repos.config.json";
+
+  let reposConfig;
+  try {
+    reposConfig = JSON.parse(await fs.promises.readFile(fileName, "utf8"));
+  } catch (e) {
+    redLog(`❌ Failed to read ${fileName}. Error: ${e}`);
+    process.exit();
+  }
+
+  if (reposConfig.length <= 0) {
+    redLog(`❌ No repos found in ${fileName}.`);
+    process.exit();
+  }
+
+  await reposConfig.asyncForEach((repo) => {
+    if (!repo.copyFrom) {
+      redLog(`❌ copyFrom is missing for ${JSON.stringify(repo)}.`);
+      process.exit();
+    }
+
+    if (!repo.pasteTo) {
+      redLog(`❌ pasteTo is missing for ${JSON.stringify(repo)}.`);
+      process.exit();
+    }
+
+    if (!repo.sidebarPosition) {
+      redLog(`❌ sidebarPosition is missing for ${JSON.stringify(repo)}.`);
+      process.exit();
+    }
+  });
+
+  return reposConfig;
+}
+
+async function fetchCopyFrom(url) {
+  let res;
+
+  try {
+    res = await fetch(url).then((res) => res.text());
+  } catch (e) {
+    redLog(`❌ ${e} - Failed to fetch ${url}. => Continue...`);
+  }
+
+  return res;
+}
+
+async function writePasteTo(path, content) {
+  greenLog(`📝 Writing to ${path}`);
+
+  let res = false;
+  try {
+    await fs.promises.writeFile(path, content);
+    res = true;
+  } catch (e) {
+    redLog(`❌ ${e} - Failed to write to ${path}. => Continue...`);
+  }
+
+  return res;
+}
+
+function getHeader(sidebarPosition) {
+  return `---
+sidebar_position: ${sidebarPosition}
+---
+\n`;
+}
+
+async function pullFunc() {
+  greenLog("🚀 Pulling changes...");
+
+  const reposConfig = await getReposConfig();
+
+  reposConfig.asyncForEach(async (repo) => {
+    const content = await fetchCopyFrom(repo.copyFrom);
+
+    if (content) {
+      const contentHeader = getHeader(repo.sidebarPosition);
+      const newContent = contentHeader + content;
+
+      await writePasteTo(process.cwd() + repo.pasteTo, newContent);
+    }
+  });
+}
+
+// -- start script
+async function setup() {
+  // find the cmd based on the first argument
+  const cmd = getCmd();
+  try {
+    cmd.fn();
+  } catch (e) {
+    redLog(`❌ Failed to run function ${cmd.cmd}. Error: ${e}`);
+    process.exit();
+  }
+}
+
+setup();


### PR DESCRIPTION
# What

For project owners, eg. GetLit CLI, it's much more convenient to update their documentation within their own repository. However, there are instances where synchronizing the documentation from the README.md file is necessary. This pull request introduces a simple tool that fetches content from a specified URL and pastes it to a designated location based on a configuration file.

# Usage

## Command

```
yarn tools pull
```

`repos.config.json`

```json
[
  {
    "sidebarPosition": 5,
    "copyFrom": "https://raw.githubusercontent.com/LIT-Protocol/getlit/main/README.md",
    "pasteTo": "/docs/ToolsAndExamples/Tools/getlitCli.md"
  }
]
```

# Demo
https://user-images.githubusercontent.com/4049673/226370873-6de328e6-1c92-426e-bb4c-69e67fad99db.mov

