### PR TITLE
add lit test token note for pkp minting

### DIFF
--- a/docs/Support/faq.md
+++ b/docs/Support/faq.md
@@ -74,6 +74,9 @@ const pkpBTCAddress = bitcoinjs.payments.p2pkh({
 }).address;
 ```
 
+### 3. "Internal JSON-RPC error" When attempting to mint a PKP
+You must have `Lit` test token in your wallet when minting a pkp, as it is used to pay the gas cost.
+
 ### 4. “Error: Invalid arrayify value”upon passing IPFS CID to functions (isPermittedActions, etc.) while interacting with PKPPermissions contract?
 
 The error is because the expected data type for IPFS CID in the contract is bytes. You have to use the conversion function below to convert your IPFS to bytes:

--- a/docs/intro/rollup.mdx
+++ b/docs/intro/rollup.mdx
@@ -31,7 +31,7 @@ To connect to Chronicle, you can click <AddRollupButton /> or manually add the n
 | Currency Symbol    | LIT                                    |
 | Currency Decimals  | 18                                     |
 
-**Note** You must have Lit test token in your wallet when minting a pkp, as it is used to pay the gas cost.
+**Note** You must have `Lit` test token in your wallet when minting a pkp, as it is used to pay the gas cost.
 
 ## Block Explorer
 

--- a/docs/intro/rollup.mdx
+++ b/docs/intro/rollup.mdx
@@ -31,6 +31,8 @@ To connect to Chronicle, you can click <AddRollupButton /> or manually add the n
 | Currency Symbol    | LIT                                    |
 | Currency Decimals  | 18                                     |
 
+**Note** You must have Lit test token in your wallet when minting a pkp, as it is used to pay the gas cost.
+
 ## Block Explorer
 
 A block explorer is available for Chronicle, providing valuable insights into the network. You can access it at https://chain.litprotocol.com/. The explorer allows you to track transactions, addresses, and other essential data on the rollup.


### PR DESCRIPTION
- adds an explicit note to Chronicle info page for requiring test token to mint PKPs.