### PR TITLE
Fix broken linking

### DIFF
--- a/docs/resources/supportedChains.md
+++ b/docs/resources/supportedChains.md
@@ -45,6 +45,7 @@ Don't see a blockchain you want?  Fill out this form for EVM chains and we'll ad
 - mantle
 - klaytn
 - publicGoodsNetwork
+- optimismGoerli
 - solana
 - solanaDevnet
 - solanaTestnet
@@ -55,7 +56,6 @@ Don't see a blockchain you want?  Fill out this form for EVM chains and we'll ad
 - cheqdMainnet
 - cheqdTestnet
 - juno
-- optimismGoerli
 
 
 ## Programmable Key Pairs

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/LIT-Protocol/docs/edit/main/website/",
+          editUrl: "https://github.com/LIT-Protocol/docs/tree/main",
           routeBasePath: "/",
         },
         // blog: {


### PR DESCRIPTION
# Explanation of fix
Previously links for `Edit this page` were redirecting to broken links on the docs GitHub repo. This PR fixes the broken links and now correctly links to the right pages.

Hopefully in the future, this makes it easier for folks to contribute to the docs!