### PR TITLE
Lit network page to v2

### DIFF
--- a/docs/network/feature-matrix.md
+++ b/docs/network/feature-matrix.md
@@ -1,4 +1,4 @@
-# Network Matrix
+# Feature Matrix
 
 Shown below is a matrix illustrating which features are available with each SDK version. 
 

--- a/docs/network/feature-matrix.md
+++ b/docs/network/feature-matrix.md
@@ -1,4 +1,4 @@
-# Feature Matrix
+# Network Matrix
 
 Shown below is a matrix illustrating which features are available with each SDK version. 
 

--- a/versioned_docs/version-2.0/resources/networkMatrix.md
+++ b/versioned_docs/version-2.0/resources/networkMatrix.md
@@ -1,0 +1,7 @@
+---
+hide_title: true
+---
+
+import Network from '/docs/network/feature-matrix.md'; 
+
+<Network />

--- a/versioned_sidebars/version-2.0-sidebars.json
+++ b/versioned_sidebars/version-2.0-sidebars.json
@@ -248,7 +248,7 @@
       "items": [
         {
           "type": "doc",
-          "label": "Network Matrix",
+          "label": "Feature Matrix",
           "id": "resources/networkMatrix"
         },
         "resources/howItWorks",

--- a/versioned_sidebars/version-2.0-sidebars.json
+++ b/versioned_sidebars/version-2.0-sidebars.json
@@ -246,6 +246,11 @@
       "collapsible": false,
       "className": "category-not-collapsible",
       "items": [
+        {
+          "type": "doc",
+          "label": "Network Matrix",
+          "id": "resources/networkMatrix"
+        },
         "resources/howItWorks",
         "resources/supportedChains",
         "resources/contracts",


### PR DESCRIPTION
# Description

Added back in the Lit Network matrix to V2 docs (will import from V3)

## Type of change

Please delete options that are not relevant.

- [-] Bug fix (non-breaking change which fixes an issue)

Link to the relevant updated sections in the Netlify preview: https://deploy-preview-130--lit-dev-docs.netlify.app/v2/resources/networkMatrix



