### PR TITLE
Fix LitNodeClient reference in installation docs for NodeJs

### DIFF
--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -67,7 +67,7 @@ Calling `connect()` on the `litNodeClient`` returns a promise that resolves when
 
 In this example stub, the litNodeClient is stored in a global variable `app.locals.litNodeClient` so that it can be used throughout the server. `app.locals` is provided by [Express](https://expressjs.com/) for this purpose. You may have to use what your own server framework provides for this purpose, instead.
 
-> Keep in mind that in the server-side implementation, the Client class is named `LitNodeClientNodeJs`.
+> Keep in mind that in the server-side implementation, the client class is named `LitNodeClientNodeJs`.
 
 `client.connect()` returns a promise that resolves when you are connected to the Lit network.
 

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -67,10 +67,12 @@ Calling `connect()` on the `litNodeClient`` returns a promise that resolves when
 
 In this example stub, the litNodeClient is stored in a global variable `app.locals.litNodeClient` so that it can be used throughout the server. `app.locals` is provided by [Express](https://expressjs.com/) for this purpose. You may have to use what your own server framework provides for this purpose, instead.
 
+> Keep in mind that in the server-side implementation, the Client class is named `LitNodeClientNodeJs`.
+
 `client.connect()` returns a promise that resolves when you are connected to the Lit network.
 
 ```js
-app.locals.litNodeClient = new LitJsSdk.LitNodeClient({
+app.locals.litNodeClient = new LitJsSdk.LitNodeClientNodeJs({
   alertWhenUnauthorized: false,
   litNetwork: 'cayenne',
 });


### PR DESCRIPTION
# Description

Fixed a Bug in the Installation guide, that references the wrong LitClient class for the server-side implementation.
The code example showed `LitNodeClient`, but the actual name is `LitNodeClientNodeJs`.
Reference: https://github.com/LIT-Protocol/js-sdk/blob/master/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts#L97

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)
