### PR TITLE
Update auth-sig.md

### DIFF
--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -101,12 +101,15 @@ const siwe = require('siwe');
 
 async function main() {
   // Initialize LitNodeClient
-  const litNodeClient = new LitJsSdk.LitNodeClientNodeJs();
+  const litNodeClient = new LitJsSdk.LitNodeClientNodeJs({
+		alertWhenUnauthorized: true,
+		litNetwork: 'cayenne',
+	});
   await litNodeClient.connect();
 
   // Initialize the signer
-  const wallet = new ethers.Wallet('<Your private key>');
-  const address = ethers.utils.getAddress(await wallet.getAddress());
+  const wallet = ethers.Wallet('<Your private key>');
+  const address = ethers.getAddress(await wallet.getAddress());
 
   // Craft the SIWE message
   const domain = 'localhost';
@@ -119,7 +122,7 @@ async function main() {
     statement,
     uri: origin,
     version: '1',
-    chainId: '1',
+    chainId: 1,
   });
   const messageToSign = siweMessage.prepareMessage();
   

--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -108,7 +108,7 @@ async function main() {
   await litNodeClient.connect();
 
   // Initialize the signer
-  const wallet = ethers.Wallet('<Your private key>');
+  const wallet = new ethers.Wallet('<Your private key>');
   const address = ethers.getAddress(await wallet.getAddress());
 
   // Craft the SIWE message

--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -102,7 +102,7 @@ const siwe = require('siwe');
 async function main() {
   // Initialize LitNodeClient
   const litNodeClient = new LitJsSdk.LitNodeClientNodeJs({
-		alertWhenUnauthorized: true,
+		alertWhenUnauthorized: false,
 		litNetwork: 'cayenne',
 	});
   await litNodeClient.connect();


### PR DESCRIPTION
Hi, its me again 😄 
Found some outdated code in the AuthSig Docs for v3 NodeJS.

# Description

- add missing args for LitNodeClientNodeJs constructor
> LitNodeClientNodeJs requires args to be passed to the constructor. Added that.

- fix ethers address creation
> Since v6, ethers doesnt expose the getAddress in the utils sub-module anymore, but as a top-level export at ethers.getAddress.

- fix SiweMessage chainId type
> SiweMessage required the chainId to be of type Number.

Code was tested with the following versions:
```ts
import LitJsSdk from 'npm:@lit-protocol/lit-node-client-nodejs@3.0.2';
import { ethers } from 'npm:ethers@6.8.0';
import siwe from 'npm:siwe@2.1.4';
```

# Modified Section

https://deploy-preview-160--lit-dev-docs.netlify.app/v3/sdk/authentication/auth-sig#obtaining-an-authsig-on-the-server-side

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)
