### PR TITLE
fix: Use Cayenne constants for v3 chains

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn add @lit-protocol/constants
+yarn add @lit-protocol/constants@cayenne
 yarn update-chains
 git add docs/resources/supported-chains.md

--- a/docs/resources/supported-chains.md
+++ b/docs/resources/supported-chains.md
@@ -36,6 +36,11 @@ Don't see a blockchain you want?  Fill out this form for EVM chains and we'll ad
 - sepolia
 - scrollAlphaTestnet
 - zksync
+- base
+- lukso
+- luksoTestnet
+- zora
+- zoraGoerli
 - zksyncTestnet
 - lineaGoerli
 - chronicleTestnet

--- a/docs/resources/supported-chains.md
+++ b/docs/resources/supported-chains.md
@@ -1,87 +1,127 @@
 # Supported Blockchains
-
-## Access Control Protocol
-
- Our Access Control Protocol supports most EVM chains, the Cosmos ecosystem, and Solana.
-
 Don't see a blockchain you want?  Fill out this form for EVM chains and we'll add it: https://forms.gle/YQV5R7WoRyPk32xc7
 
-- ethereum
-- polygon
-- fantom
-- xdai
-- bsc
-- arbitrum
-- avalanche
-- fuji
-- harmony
-- mumbai
-- goerli
-- cronos
-- optimism
-- celo
-- aurora
-- eluvio
-- alfajores
-- xdc
-- evmos
-- evmosTestnet
-- bscTestnet
-- baseGoerli
-- moonbeam
-- moonriver
-- moonbaseAlpha
-- filecoin
-- hyperspace
-- sepolia
-- scrollAlphaTestnet
-- zksync
-- base
-- lukso
-- luksoTestnet
-- zora
-- zoraGoerli
-- zksyncTestnet
-- lineaGoerli
-- chronicleTestnet
-- chiado
-- zkEvm
-- mantleTestnet
-- mantle
-- klaytn
-- publicGoodsNetwork
-- optimismGoerli
-- waevEclipseTestnet
-- waevEclipseDevnet
-- solana
-- solanaDevnet
-- solanaTestnet
-- cosmos
-- kyve
-- evmosCosmos
-- evmosCosmosTestnet
-- cheqdMainnet
-- cheqdTestnet
-- juno
-
+## Access Control Protocol
+ Our Access Control Protocol supports most EVM chains, the Cosmos ecosystem, and Solana.
 
 ## Programmable Key Pairs
+ PKPs rely on the [ECDSA](https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/) for digital signatures. This makes them inherently "compatible" with chains that rely on this same cryptographic primitive.
 
- PKPs rely on the [ECDSA](https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/) for digital signatures. This makes them inherently "compatible" with chains that rely on this same cryptographic primitive. This includes:
+You can learn more about compatible chains [here.](http://ethanfast.com/top-crypto.html)
 
-- bitcoin
+## Cayenne (Access Control & PKP)
 
-- ethereum (and many of the EVM chains you see above)
-
-- binance
+- ethereum
 
 - polygon
 
-- cosmos
+- fantom
+
+- xdai
+
+- bsc
+
+- arbitrum
+
+- avalanche
+
+- fuji
+
+- harmony
+
+- mumbai
+
+- goerli
+
+- cronos
+
+- optimism
+
+- celo
+
+- aurora
+
+- eluvio
+
+- alfajores
+
+- xdc
+
+- evmos
+
+- evmosTestnet
+
+- bscTestnet
+
+- baseGoerli
+
+- moonbeam
+
+- moonriver
+
+- moonbaseAlpha
 
 - filecoin
 
-- theta
+- hyperspace
 
-You can learn more about compatible chains [here.](http://ethanfast.com/top-crypto.html)
- 
+- sepolia
+
+- scrollAlphaTestnet
+
+- zksync
+
+- base
+
+- lukso
+
+- luksoTestnet
+
+- zora
+
+- zoraGoerli
+
+- zksyncTestnet
+
+- lineaGoerli
+
+- chronicleTestnet
+
+- chiado
+
+- zkEvm
+
+- mantleTestnet
+
+- mantle
+
+- klaytn
+
+- publicGoodsNetwork
+
+- optimismGoerli
+
+- waevEclipseTestnet
+
+- waevEclipseDevnet
+
+- solana
+
+- solanaDevnet
+
+- solanaTestnet
+
+- cosmos
+
+- kyve
+
+- evmosCosmos
+
+- evmosCosmosTestnet
+
+- cheqdMainnet
+
+- cheqdTestnet
+
+- juno
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.1.0",
     "@docusaurus/plugin-google-analytics": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
-    "@lit-protocol/constants": "^2.2.61",
+    "@lit-protocol/constants": "^3.0.24",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/updateChains.js
+++ b/updateChains.js
@@ -1,26 +1,27 @@
 const { ALL_LIT_CHAINS } = require("@lit-protocol/constants");
 const fs = require("fs");
 
-function capitalizeFirstLetter(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
 console.log("Updating chains via updateChains.js");
 
-let md = `# Supported Blockchains\n\n## Access Control Protocol\n\n`;
+let md = `# Supported Blockchains\n`;
 
 md +=
-  " Our Access Control Protocol supports most EVM chains, the Cosmos ecosystem, and Solana.\n\nDon't see a blockchain you want?  Fill out this form for EVM chains and we'll add it: https://forms.gle/YQV5R7WoRyPk32xc7\n\n";
+  "Don't see a blockchain you want?  Fill out this form for EVM chains and we'll add it: https://forms.gle/YQV5R7WoRyPk32xc7\n\n";
+
+md +=
+  "## Access Control Protocol\n Our Access Control Protocol supports most EVM chains, the Cosmos ecosystem, and Solana.\n\n";
+
+md +=
+  "## Programmable Key Pairs\n PKPs rely on the [ECDSA](https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/) for digital signatures. This makes them inherently \"compatible\" with chains that rely on this same cryptographic primitive.\n\n";
+
+md +=
+  "You can learn more about compatible chains [here.](http://ethanfast.com/top-crypto.html)\n\n";
+
+md +=
+  "## Cayenne (Access Control & PKP)\n\n";
 
 md += Object.keys(ALL_LIT_CHAINS)
-  .map((c) => `- ${c}\n`)
+  .map((c) => `- ${c}\n\n`)
   .join("");
 
-md += `\n\n## Programmable Key Pairs\n\n PKPs rely on the [ECDSA](https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/) for digital signatures. This makes them inherently "compatible" with chains that rely on this same cryptographic primitive. This includes:\n\n- bitcoin\n
-- ethereum (and many of the EVM chains you see above)\n
-- binance\n
-- polygon\n
-- cosmos\n
-- filecoin\n
-- theta\n\nYou can learn more about compatible chains [here.](http://ethanfast.com/top-crypto.html)\n `;
 fs.writeFileSync("docs/resources/supported-chains.md", md);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,34 +2242,36 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lit-protocol/auth-helpers@2.2.61":
-  version "2.2.61"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-2.2.61.tgz#b1741090ae0b03c952123f4fa71523e1d604347f"
-  integrity sha512-2VzwFaHwMHN4raQ5RsKfXz02KqQ2hbPHCf0GPfXify79ZAUYp/BIsOyo1mpVlVkA1moaQ0zadHAlTdcBVNCVtQ==
+"@lit-protocol/auth-helpers@3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.0.24.tgz#e72206887b7aaad193de66837538859504705d2d"
+  integrity sha512-8Qt09e59as/oyRS4phxCBdHonmZBSs4ZMK15Qi3wUtT1f/bJ4pYE1PqoD877kWbR1ri4Ov4dCw0IcW7tn97sZg==
   dependencies:
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/constants@^2.2.61":
-  version "2.2.61"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-2.2.61.tgz#0f584c27ec1fb5966d17d278ed398a33afbe0c95"
-  integrity sha512-M4jvbawMX0QgPriTT8H4iymkh7uJXjqPZvm+pr/5bIsDbarng5eRpHd1gB6DPX9n5RV9X+rSk1FFSoahUeWieg==
+"@lit-protocol/constants@^3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.0.24.tgz#dc93cf89099a34002de3c7800accc4dabbdec512"
+  integrity sha512-SosWglxjaS4kVUfrb1Wx4k38WmvCOoYO6dkNzSFl+Qe5mtrPaoYrJuD+Exvcu7FQVUIkwq9yILBiNHkYhDruSw==
   dependencies:
-    "@lit-protocol/auth-helpers" "2.2.61"
-    "@lit-protocol/types" "2.2.61"
+    "@lit-protocol/auth-helpers" "3.0.24"
+    "@lit-protocol/types" "3.0.24"
     ethers "^5.7.1"
+    jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/types@2.2.61":
-  version "2.2.61"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-2.2.61.tgz#a1db4348cc17b1c7e0368e52a588f16842cc3d4a"
-  integrity sha512-5BFOFZlrlWPNvkROcw3690uypFdeIr/e7Kqr3JS/22RH1dsAz9Oq0kJGXe+qEF4hp699BvyLQzsqd15CzY5+oA==
+"@lit-protocol/types@3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.0.24.tgz#4761fef4a89353e0ec2bb420e6c39019ea1d9234"
+  integrity sha512-7nxc4hs1A5BhQcByMpaTK4acZckzMXoy1fSymVgGNFO37xEfL/mN9Oad1+7CdET9/mbTQRyzA2LcYWFJ9FvCOw==
   dependencies:
-    "@lit-protocol/auth-helpers" "2.2.61"
+    "@lit-protocol/auth-helpers" "3.0.24"
     ethers "^5.7.1"
+    jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
@@ -5555,6 +5557,11 @@ image-size@^1.0.1:
   dependencies:
     queue "6.0.2"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 immer@^9.0.7:
   version "9.0.21"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
@@ -6067,6 +6074,16 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -6103,6 +6120,13 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lilconfig@^2.0.3:
   version "2.1.0"
@@ -6722,6 +6746,11 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
+
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -7476,7 +7505,7 @@ react@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-readable-stream@^2.0.1:
+readable-stream@^2.0.1, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==


### PR DESCRIPTION
# Bugs

In the v3 docs we pull the latest chains from v2 SDK hence the chains aren't updated.

# Fixes

Use `@lit-protocol/constants@cayenne` instead of `@lit-protocol/constants` which downloads the latest v3 SDK's constant.

# Updates

Reorganized the v3 docs "Supported Blockchains" to match the updated corresponding v2 docs.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

General
- [X] I have performed a self-review of my code
- [X] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [X] I have checked the additions are concise
- [X] Language is consistent with existing documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


