### PR TITLE
Updated re-directs to V3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -649,7 +649,7 @@ force = false
 
 [[redirects]]
   from = "/*"
-  to = "/v2/:splat"
+  to = "/v3/:splat"
   status = 302
   force = false
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -656,7 +656,7 @@ force = false
 # home redirect 7/11/23, pointing to V2... update to V3 when ready
 [[redirects]]
   from = "/"
-  to = "/v2/"
+  to = "/v3/"
   status = 302
   force = false
 


### PR DESCRIPTION
* Updated `netlify.toml` to point to V3

# Description

- Re-directs the homepage to v3 instead of v2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Introducing new feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [x] Link 1: updated line 659 to "/v3/"

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [x] Language is consistent with existing documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

