### PR TITLE
Fixed typo in session signature docs

### DIFF
--- a/docs/sdk/authentication/session-sigs/get-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-session-sigs.md
@@ -61,7 +61,7 @@ const sessionSigs = await litNodeClient.getSessionSigs({
   resourceAbilityRequests: [
     {
       resource: litResource,
-      ability: LitAbility.AccessControlDescription
+      ability: LitAbility.AccessControlConditionDecryption
     }
   ],
   authNeededCallback,


### PR DESCRIPTION
`LitAbility.AccessControlDescription` is corrected as `LitAbility.AccessControlConditionDecryption` in https://developer.litprotocol.com/v3/sdk/authentication/session-sigs/get-session-sigs/