### PR TITLE
feat: Use latest blockhash for nonce while crafting authSig/sessionSigs

### DIFF
--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -14,7 +14,7 @@ You can use any signature compliant with EIP-4361, also known as Sign in with Et
 {
 	"sig": "0x18720b54cf0d29d618a90793d5e76f4838f04b559b02f1f01568d8e81c26ae9536e11bb90ad311b79a5bc56149b14103038e5e03fee83931a146d93d150eb0f61c",
 	"derivedVia": "web3.eth.personal.sign",
-	"signedMessage": "localhost wants you to sign in with your Ethereum account:\n0x1cD4147AF045AdCADe6eAC4883b9310FD286d95a\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: gzdlw7mR57zMcGFzz\nIssued At: 2022-04-15T22:58:44.754Z",
+	"signedMessage": "localhost wants you to sign in with your Ethereum account:\n0x1cD4147AF045AdCADe6eAC4883b9310FD286d95a\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553\nIssued At: 2022-04-15T22:58:44.754Z",
 	"address": "0x1cD4147AF045AdCADe6eAC4883b9310FD286d95a"
 }
 ```
@@ -94,6 +94,8 @@ If you want to clear the `AuthSig` stored in local storage, you can call the [`d
 
 If you want to obtain an `AuthSig` on the server-side, you can instantiate an `ethers.Signer` to sign a SIWE message, which will produce a signature that can be used in an `AuthSig` object.
 
+**Note:** The nonce should be the latest Ethereum blockhash returned by the nodes during the handshake
+
 ```js
 const LitJsSdk = require('@lit-protocol/lit-node-client-nodejs');
 const { ethers } = require("ethers");
@@ -106,6 +108,8 @@ async function main() {
 		litNetwork: 'cayenne',
 	});
   await litNodeClient.connect();
+
+  let nonce = litNodeClient.getLatestBlockhash();
 
   // Initialize the signer
   const wallet = new ethers.Wallet('<Your private key>');
@@ -123,6 +127,7 @@ async function main() {
     uri: origin,
     version: '1',
     chainId: 1,
+    nonce,
   });
   const messageToSign = siweMessage.prepareMessage();
   

--- a/docs/sdk/authentication/session-sigs/get-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-session-sigs.md
@@ -6,6 +6,8 @@ sidebar_position: 2
 
 You can use any wallet or auth method to generate session signatures with the `getSessionSigs()` function from the Lit SDK. This function generates a session keypair and uses a callback function that signs the generated session key to create an `AuthSig` that is scoped to specific capabilities.
 
+**Note:** The nonce should be the latest Ethereum blockhash returned by the nodes during the handshake
+
 ```javascript
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
 import { LitAccessControlConditionResource, LitAbility } from '@lit-protocol/auth-helpers';
@@ -19,6 +21,8 @@ const litNodeClient = new LitNodeClient({
   debug: true,
 });
 await litNodeClient.connect();
+
+let nonce = litNodeClient.getLatestBlockhash();
 
 /**
  * When the getSessionSigs function is called, it will generate a session key
@@ -37,6 +41,7 @@ const authNeededCallback = async ({ chain, resources, expiration, uri }) => {
     chainId: "1",
     expirationTime: expiration,
     resources,
+    nonce,
   });
   const toSign = message.prepareMessage();
   const signature = await wallet.signMessage(toSign);

--- a/docs/sdk/authentication/session-sigs/intro.md
+++ b/docs/sdk/authentication/session-sigs/intro.md
@@ -37,7 +37,7 @@ Given the following example `AuthSig`:
         URI: lit:session:6a1f1e8a00b61867b85eaf329d6fdf855220ac3e32f44ec13e4db0dd303dea6a
         Version: 1
         Chain ID: 1
-        Nonce: ZfYjGsNyaDDFlaftP
+        Nonce: 0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553
         Issued At: 2022-10-30T08:25:33.371Z
         Expiration Time: 2022-11-06T08:25:33.348Z
         Resources:
@@ -72,7 +72,7 @@ Here is an example `SessionSig` that uses a session keypair to sign the `AuthSig
                 URI: lit:session:6a1f1e8a00b61867b85eaf329d6fdf855220ac3e32f44ec13e4db0dd303dea6a
                 Version: 1
                 Chain ID: 1
-                Nonce: ZfYjGsNyaDDFlaftP
+                Nonce: 0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553
                 Issued At: 2022-10-30T08:25:33.371Z
                 Expiration Time: 2022-11-06T08:25:33.348Z
                 Resources:


### PR DESCRIPTION
# Description

Update examples to use the latest blockhash while crafting the authSig/sessionSig as its nonce.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

General
- [X] I have performed a self-review of my code
- [X] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [X] I have checked the additions are concise
- [X] Language is consistent with existing documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [X] included a beginner friendly explanation
- [X] included a basic technical introduction and code sample
- [X] new terms are defined, both in relevant new pages and in the glossary

