### PR TITLE
feat: Update authSig generation to use blockhash as its nonce

### DIFF
--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -39,8 +39,13 @@ import { checkAndSignAuthMessage } from '@lit-protocol/lit-node-client';
 
 const authSig = await checkAndSignAuthMessage({
   chain: "ethereum",
+  nonce,
 });
 ```
+
+:::note
+Be sure to use the latest blockhash from the `litNodeClient` as the nonce.
+:::
 
 When called, `checkAndSignAuthMessage` triggers a wallet selection popup in the user's browser. The user is then asked to sign a message, confirming ownership of their crypto address. The signature of the signed message is returned as the `authSig` variable.
 
@@ -60,11 +65,16 @@ const authSig = await ethConnect.signAndSaveAuthMessage({
   account: walletAddress,
   chainId: 1,
   expiration: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+  nonce,
 });
 ```
 
 :::note
 Be sure to import `cosmosConnect` and `solConnect` for Cosmos and Solana respectively.
+:::
+
+:::note
+Be sure to use the latest blockhash from the `litNodeClient` as the nonce.
 :::
 
 ### Using EIP-1271 for Account Abstraction

--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -44,7 +44,7 @@ const authSig = await checkAndSignAuthMessage({
 ```
 
 :::note
-Be sure to use the latest blockhash from the `litNodeClient` as the nonce.
+Be sure to use the latest blockhash from the `litNodeClient` as the nonce. You can get it from the `litNodeClient.getLatestBlockhash()`.
 :::
 
 When called, `checkAndSignAuthMessage` triggers a wallet selection popup in the user's browser. The user is then asked to sign a message, confirming ownership of their crypto address. The signature of the signed message is returned as the `authSig` variable.
@@ -74,7 +74,7 @@ Be sure to import `cosmosConnect` and `solConnect` for Cosmos and Solana respect
 :::
 
 :::note
-Be sure to use the latest blockhash from the `litNodeClient` as the nonce.
+Be sure to use the latest blockhash from the `litNodeClient` as the nonce. You can get it from the `litNodeClient.getLatestBlockhash()`.
 :::
 
 ### Using EIP-1271 for Account Abstraction

--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Getting Started
+# Quick Start
 
 :::note
 💡 Lit Actions and PKPs are still heavily in development and things may change.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.1.0",
     "@docusaurus/plugin-google-analytics": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
-    "@lit-protocol/constants": "^3.0.24",
+    "@lit-protocol/constants": "^3.0.27",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,34 +2242,34 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lit-protocol/auth-helpers@3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.0.24.tgz#e72206887b7aaad193de66837538859504705d2d"
-  integrity sha512-8Qt09e59as/oyRS4phxCBdHonmZBSs4ZMK15Qi3wUtT1f/bJ4pYE1PqoD877kWbR1ri4Ov4dCw0IcW7tn97sZg==
+"@lit-protocol/auth-helpers@3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.0.27.tgz#865eab381f5b9debac2165db2d1953bb10bad708"
+  integrity sha512-cIzJguIRUpjBma6hNjzXAO3MsB7499KRlpTTmFRbsZZfuM+NM6T/2vM4vaslX1JtwJ6YqRoBibSp4kRSP4t+iQ==
   dependencies:
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/constants@^3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.0.24.tgz#dc93cf89099a34002de3c7800accc4dabbdec512"
-  integrity sha512-SosWglxjaS4kVUfrb1Wx4k38WmvCOoYO6dkNzSFl+Qe5mtrPaoYrJuD+Exvcu7FQVUIkwq9yILBiNHkYhDruSw==
+"@lit-protocol/constants@^3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.0.27.tgz#e228e8916b20d87ef70929403d268e4cd192cba0"
+  integrity sha512-73scvCbW4IsCzjuxFBqG73iV3JJEqOIVuWXkhPKIcPJQPN/IAtkrS+GAGDZauG6rYcwDPLJae5iLQxq7VKGiYA==
   dependencies:
-    "@lit-protocol/auth-helpers" "3.0.24"
-    "@lit-protocol/types" "3.0.24"
+    "@lit-protocol/auth-helpers" "3.0.27"
+    "@lit-protocol/types" "3.0.27"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/types@3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.0.24.tgz#4761fef4a89353e0ec2bb420e6c39019ea1d9234"
-  integrity sha512-7nxc4hs1A5BhQcByMpaTK4acZckzMXoy1fSymVgGNFO37xEfL/mN9Oad1+7CdET9/mbTQRyzA2LcYWFJ9FvCOw==
+"@lit-protocol/types@3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.0.27.tgz#9efc92505d2dcae08ab64cd2113efb09108bc44c"
+  integrity sha512-x/fL1iGNxSEN+wfhhfPvDjeKH+G6Q8CrWPdfZ7eYuuP/3nUH0AFqZHy6f+R1YL83HMdIpAWpjeL2bgKoum6kzA==
   dependencies:
-    "@lit-protocol/auth-helpers" "3.0.24"
+    "@lit-protocol/auth-helpers" "3.0.27"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"


### PR DESCRIPTION
# Description

Update `checkAndSignAuthMessage` & `signAndSaveAuthMessage` to use the blockhash from the client as its nonce.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

General
- [X] I have performed a self-review of my code
- [X] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [X] I have checked the additions are concise
- [X] Language is consistent with existing documentation
- [X] My changes generate no new warnings

If I have added a new concept, I have
- [X] included a beginner friendly explanation
- [X] included a basic technical introduction and code sample

