### PR TITLE
add more to examples of eth wallet provider

### DIFF
--- a/docs/sdk/wallets/minting.md
+++ b/docs/sdk/wallets/minting.md
@@ -57,15 +57,22 @@ const mintInfo = await contractClient.mintWithAuth({
 
 The relayer is an open source project, and we run one for your use.  The source code is available [here](https://github.com/LIT-Protocol/relay-server).  If you want to use our Relayer, you'll need a free API key which you can get by filling out [this form](https://forms.gle/RNZYtGYTY9BcD9MEA).
 
-```js
-import { AuthMethodScope, AuthMethodType } from '@lit-protocol/constants';
+### Authenticating using `signMessage` Callback
 
+```js
+import { LitAuthClient } from '@lit-protocol/lit-auth-client';
+import { AuthMethodScope, AuthMethodType, ProviderType } from '@lit-protocol/constants';
+import * as ethers from 'ethers';
+
+const provider = new ethers.providers.JsonRpcProvider("your rpc url");
+let wallet = new ethers.Wallet("your wallet private key", provider);
 const authProvider = litAuthClient.initProvider(ProviderType.EthWallet);
 
-const authMethod = {
-  authMethodType: AuthMethodType.EthWallet,
-  accessToken: ...,
-};
+let authMethod = authProvider.authenticate({
+  signMessage: (message: string) => {
+    return await wallet.signMessage(message);
+  }
+});
 
 // -- setting scope for the auth method
 // <https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scopes>
@@ -78,6 +85,31 @@ const mintTx = await authProvider.mintPKPThroughRelayer(
   options
 );
 ```
+
+### Authenticating using `Web3 Provider`
+
+```js
+import { LitAuthClient } from '@lit-protocol/lit-auth-client';
+import { AuthMethodScope, AuthMethodType, ProviderType } from '@lit-protocol/constants';
+import {Wallet} from 'ethers';
+
+const authProvider = litAuthClient.initProvider(ProviderType.EthWallet);
+
+// Will call `checkAndSignAuthMessage({chain: ethereum})`
+let authMethod = await authProvider.authenticate({chain: "ethereum"});
+
+// -- setting scope for the auth method
+// <https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scopes>
+const options = {
+  permittedAuthMethodScopes: [[AuthMethodScope.SignAnything]],
+};
+
+const mintTx = await authProvider.mintPKPThroughRelayer(
+  authMethod,
+  options
+);
+```
+
 
 **Demos**: 
 1. [Minting a PKP with an auth method and permitted scopes (Easy)](https://github.com/LIT-Protocol/js-sdk/blob/feat/SDK-V3/e2e-nodejs/group-contracts/test-contracts-write-mint-a-pkp-and-set-scope-1-2-easy.mjs)

--- a/docs/sdk/wallets/minting.md
+++ b/docs/sdk/wallets/minting.md
@@ -58,7 +58,7 @@ const mintInfo = await contractClient.mintWithAuth({
 The relayer is an open source project, and we run one for your use.  The source code is available [here](https://github.com/LIT-Protocol/relay-server).  If you want to use our Relayer, you'll need a free API key which you can get by filling out [this form](https://forms.gle/RNZYtGYTY9BcD9MEA).
 
 ### Authenticating using `signMessage` Callback
-
+If you wish to sign with an ethers wallet type or `signer` you may use the `signMessage` callback to implement a signing callback for the `SIWE` message.
 ```js
 import { LitAuthClient } from '@lit-protocol/lit-auth-client';
 import { AuthMethodScope, AuthMethodType, ProviderType } from '@lit-protocol/constants';
@@ -87,7 +87,8 @@ const mintTx = await authProvider.mintPKPThroughRelayer(
 ```
 
 ### Authenticating using `Web3 Provider`
-
+In the case where you wish to generagte a signature from a browser extension wallet (MetaMask, Brave Wallet, etc)
+you may simply call `authenticate` which calls `checkAndSignAuthMessage`.
 ```js
 import { LitAuthClient } from '@lit-protocol/lit-auth-client';
 import { AuthMethodScope, AuthMethodType, ProviderType } from '@lit-protocol/constants';


### PR DESCRIPTION
# Description

- Adds more examples for `eth wallet provider` for creating new pkp's with type `EthWallet`
provides examples for 
- In memory wallet
- Using `web3` provider for extension requests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

