### PR TITLE
add example for users that want to change the google oauth flow

### DIFF
--- a/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
+++ b/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
@@ -34,25 +34,76 @@ async function authWithGoogle() {
 }
 ```
 
-At the start of the authentication flow, users will be redirected to the social login page hosted by Lit. Once users have successfully signed in, they will be redirected back to your web app.
-
-In case you want to use a custom OAuth project URL instead of the one provided by Lit, you can pass a callback in the `signIn` method and modify the URL as needed.
+By default, Lit's social login providers use Lit's OAuth project. In case you want to use a custom OAuth project instead of the one provided by Lit, you can pass a callback in the `signIn` method and modify the URL as needed.
 
 ```javascript
+// Set up LitAuthClient
+const litAuthClient = new LitAuthClient({
+  litRelayConfig: {
+     // Request a Lit Relay Server API key here: https://forms.gle/RNZYtGYTY9BcD9MEA
+    relayApiKey: '<Your Lit Relay Server API Key>',
+  },
+});
+
+// Initialize Google provider
+litAuthClient.initProvider(ProviderType.Google, {
+  // The URL of your web app where users will be redirected after authentication
+  redirectUri: '<Your redirect URI>',
+});
+
+// Begin login flow with Google but using your own OAuth project
 async function authWithGoogle() {
   const provider = litAuthClient.getProvider(
     ProviderType.Google
   );
   await provider.signIn((url) => {
-    // modify url as needed
+    const myURL = new URL(url);
+    
+    // Modify URL as needed
+    myURL.host = 'mycustomdomain.com';
+    myURL.pathname = '/myCustomOauthLoginFlow';
+    // myURL.searchParams.get('app_redirect') is your redirect URI for logged in users
+    
     window.location.assign(url);
   });
 }
 ```
 
-:::note
-For Discord OAuth, you will initialize the provider with `ProviderType.Discord`.
-:::
+To login using Discord, you need to initialize the provider with `ProviderType.Discord` and pass it a Discord `clientId` along `redirectUri`
+
+```javascript
+// Set up LitAuthClient
+const litAuthClient = new LitAuthClient({
+  litRelayConfig: {
+     // Request a Lit Relay Server API key here: https://forms.gle/RNZYtGYTY9BcD9MEA
+    relayApiKey: '<Your Lit Relay Server API Key>',
+  },
+});
+
+// Initialize Discord provider
+litAuthClient.initProvider(ProviderType.Discord, {
+  // The URL of your web app where users will be redirected after authentication
+  redirectUri: '<Your redirect URI>',
+  clientId: '<Your Discord Client ID>',
+});
+
+// Begin login flow with Discord
+async function authWithDiscord() {
+  const provider = litAuthClient.getProvider(
+    ProviderType.Discord
+  );
+  await provider.signIn((url) => {
+    const myURL = new URL(url);
+    
+    // Modify URL as needed
+    myURL.host = 'mycustomdomain.com';
+    myURL.pathname = '/myCustomOauthLoginFlow';
+    // myURL.searchParams.get('app_redirect') is your redirect URI for logged in users
+    
+    window.location.assign(url);
+  });
+}
+```
 
 :::note
 

--- a/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
+++ b/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
@@ -36,6 +36,20 @@ async function authWithGoogle() {
 
 At the start of the authentication flow, users will be redirected to the social login page hosted by Lit. Once users have successfully signed in, they will be redirected back to your web app.
 
+In case you want to use a custom OAuth project URL instead of the one provided by Lit, you can pass a callback in the `signIn` method and modify the URL as needed.
+
+```javascript
+async function authWithGoogle() {
+  const provider = litAuthClient.getProvider(
+    ProviderType.Google
+  );
+  await provider.signIn((url) => {
+    // modify url as needed
+    window.location.assign(url);
+  });
+}
+```
+
 :::note
 For Discord OAuth, you will initialize the provider with `ProviderType.Discord`.
 :::


### PR DESCRIPTION
# Description

This PR adds an example for users that want to change the google oauth context they are use instead of relying on our hosted login server

## Type of change

Please delete options that are not relevant.

- [x] Adding documentation

Link to the relevant updated sections in the Netlify preview

- [x] [Link 1](https://deploy-preview-200--lit-dev-docs.netlify.app/v3/sdk/authentication/session-sigs/auth-methods/social-login): Adding an example changing the oauth flow url

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [x] Language is consistent with existing documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

