### PR TITLE
Rename auth method scope naming from OnlySignMessages to PersonalSign

### DIFF
--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -60,7 +60,7 @@ await contractClient.connect();
 
 ## Mint the PKP
 
-Now that we've the ContractsSDK initialized we're ready to mint the PKP using it. Since we want to allow out PKP to sign messages we have to add Auth Method scopes for `SigningAnything` & `OnlySignMessages` as below otherwise you'll get an error stating that the PKP isn't authorized to sign.
+Now that we've the ContractsSDK initialized we're ready to mint the PKP using it. Since we want to allow out PKP to sign messages we have to add Auth Method scopes for `SigningAnything` & `PersonalSign` as below otherwise you'll get an error stating that the PKP isn't authorized to sign.
 
 **Note:** You're gonna need an AuthSig for setting the `authMethod`. In the browser you can use `checkAndSignAuthMessage` or use [Hot wallet signing](https://developer.litprotocol.com/v3/support/faq/#1-cant-use-checkandsignauthmessage-in-a-backend-project) in the backend.
 
@@ -143,7 +143,7 @@ const mintInfo = await contractClient.mintWithAuth({
   scopes: [
     AuthMethodScope.NoPermissions,
     AuthMethodScope.SignAnything,
-    AuthMethodScope.OnlySignMessages,
+    AuthMethodScope.PersonalSign,
   ],
 });
 ```
@@ -162,7 +162,7 @@ await contractClient.pkpPermissionsContract.read.getPermittedAuthMethodScopes(
 );
 
 const signAnythingScope = scopes[1];
-const onlySignMessagesScope = scopes[2];
+const personalSignScope = scopes[2];
 ```
 
 ## Lit Action Signing with the PKP

--- a/docs/sdk/wallets/minting.md
+++ b/docs/sdk/wallets/minting.md
@@ -38,7 +38,7 @@ const mintInfo = await contractClient.mintWithAuth({
   scopes: [
 		// AuthMethodScope.NoPermissions,
 		AuthMethodScope.SignAnything, 
-		AuthMethodScope.OnlySignMessages
+		AuthMethodScope.PersonalSign
 	],
 });
 


### PR DESCRIPTION
# Description

To be published together with https://github.com/LIT-Protocol/js-sdk/pull/334

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

General
- [x] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

