### PR TITLE
Fix/get session sigs params

### DIFF
--- a/docs/sdk/authentication/session-sigs/auth-methods/email-sms.md
+++ b/docs/sdk/authentication/session-sigs/auth-methods/email-sms.md
@@ -147,21 +147,21 @@ Below is an example of an authentication method from successful authentication
 }
 ```
 
-### Generating `SessionSigs`
+## Generating `SessionSigs`
 
-After successfully authenticating with an `AuthMethod`, you can generate `Session Signatures` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, a PKP public key, and other session-specific arguments such as `resourceAbilityRequests` and returns a `SessionSig` object.
+After successfully authenticating with a social login provider, you can generate `SessionSigs` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, optional `LitNodeClient` object, a PKP public key, and other session-specific arguments in `SessionSigsParams` object such as `resourceAbilityRequests` and `chain`. View the [API Docs](https://js-sdk.litprotocol.com/interfaces/types_src.BaseProviderSessionSigsParams.html).
 
 ```javascript
 // Get session signatures for the given PKP public key and auth method
 const sessionSigs = await provider.getSessionSigs({
-  authMethod: "<AuthMethod object returned from authenticate()>",
+  authMethod: '<AuthMethod object returned from authenticate()>',
+  pkpPublicKey: '<YOUR PKP PUBLIC KEY>'
   sessionSigsParams: {
-    chain: "ethereum",
-    resourceAbilityRequests: [
-      {
+    chain: 'ethereum',
+    resourceAbilityRequests: [{
         resource: litResource,
-        ability: LitAbility.AccessControlConditionDecryption,
-      },
+        ability: LitAbility.AccessControlConditionDecryption
+      }
     ],
   },
 });

--- a/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
+++ b/docs/sdk/authentication/session-sigs/auth-methods/social-login.md
@@ -138,12 +138,13 @@ With the `AuthMethod` object, you can mint or fetch PKPs associated with the aut
 
 ## Generating `SessionSigs`
 
-After successfully authenticating with a social login provider, you can generate `SessionSigs` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, a PKP public key, and other session-specific arguments such as `resourceAbilityRequests` and returns a `SessionSig` object.
+After successfully authenticating with a social login provider, you can generate `SessionSigs` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, optional `LitNodeClient` object, a PKP public key, and other session-specific arguments in `SessionSigsParams` object such as `resourceAbilityRequests` and `chain`. View the [API Docs](https://js-sdk.litprotocol.com/interfaces/types_src.BaseProviderSessionSigsParams.html).
 
 ```javascript
 // Get session signatures for the given PKP public key and auth method
 const sessionSigs = await provider.getSessionSigs({
   authMethod: '<AuthMethod object returned from authenticate()>',
+  pkpPublicKey: '<YOUR PKP PUBLIC KEY>'
   sessionSigsParams: {
     chain: 'ethereum',
     resourceAbilityRequests: [{

--- a/docs/sdk/authentication/session-sigs/auth-methods/web-authn.md
+++ b/docs/sdk/authentication/session-sigs/auth-methods/web-authn.md
@@ -77,16 +77,16 @@ The `authenticate` method returns an `AuthMethod` object containing the authenti
 
 ## Generating `SessionSigs`
 
-After successfully authenticating with a WebAuthn credential, you can generate `SessionSigs` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, a PKP public key, and other session-specific arguments such as `resourceAbilityRequests` and returns a `SessionSig` object.
+After successfully authenticating with a social login provider, you can generate `SessionSigs` using the provider's `getSessionSigs` method. The `getSessionSigs` method takes in an `AuthMethod` object, optional `LitNodeClient` object, a PKP public key, and other session-specific arguments in `SessionSigsParams` object such as `resourceAbilityRequests` and `chain`. View the [API Docs](https://js-sdk.litprotocol.com/interfaces/types_src.BaseProviderSessionSigsParams.html).
 
 ```javascript
 // Get session signatures for the given PKP public key and auth method
 const sessionSigs = await provider.getSessionSigs({
   authMethod: '<AuthMethod object returned from authenticate()>',
+  pkpPublicKey: '<YOUR PKP PUBLIC KEY>'
   sessionSigsParams: {
     chain: 'ethereum',
-    resourceAbilityRequests: [
-      {
+    resourceAbilityRequests: [{
         resource: litResource,
         ability: LitAbility.AccessControlConditionDecryption
       }


### PR DESCRIPTION
### Fixes Issue: [LIT-2394](https://linear.app/litprotocol/issue/LIT-2394/section-for-creating-the-sessionsigs-from-social-login-has-incomplete)

# Description

The section for creating the sessionSigs from Social Login is incorrect - https://developer.litprotocol.com/v3/sdk/authentication/session-sigs/auth-methods/social-login/#generating-sessionsigs. It has incomplete parameters.

Trying to update the docs for it!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

