### PR TITLE
Added how to add Lit Action as an Auth Method

### DIFF
--- a/docs/sdk/wallets/auth-methods.md
+++ b/docs/sdk/wallets/auth-methods.md
@@ -35,6 +35,8 @@ Several auth methods are supported by Lit directly. These include methods config
 
 Check out the implementation details within the SDK section [here](../../sdk/authentication/session-sigs/auth-methods/overview).
 
+**Note:** When using the `ACTION` Auth Method, it's necessary to convert the IPFS CID from base58 encoding to byte-like before passing it to the Lit Protocol SDK. You can achieve this conversion using the `getBytesFromMultihash` function provided in the `utils` module.
+
 ### Auth Method Scopes
 
 Auth methods support scoping, which permits what they can be used for within Lit. These scopes are passed in to the "scopes" array as numbers when adding an auth method, or minting a PKP with PKPHelper. An overview of minting with scopes is provided in this [section](../wallets/minting). The scopes are as follows:

--- a/docs/sdk/wallets/auth-methods.md
+++ b/docs/sdk/wallets/auth-methods.md
@@ -35,7 +35,7 @@ Several auth methods are supported by Lit directly. These include methods config
 
 Check out the implementation details within the SDK section [here](../../sdk/authentication/session-sigs/auth-methods/overview).
 
-**Note:** When using the `ACTION` Auth Method, it's necessary to convert the IPFS CID from base58 encoding to byte-like before passing it to the Lit Protocol SDK. You can achieve this conversion using the `getBytesFromMultihash` function provided in the `utils` module.
+**Note:** When using the `ACTION` Auth Method, it's necessary to convert the IPFS CID from base58 encoding to bytes-like before passing it to the Lit Protocol SDK. You can achieve this conversion using the `getBytesFromMultihash` function provided in the `utils` module of the `contracts-sdk`.
 
 ### Auth Method Scopes
 


### PR DESCRIPTION
### Fixes Issue: [LIT-2420](https://linear.app/litprotocol/issue/LIT-2420/missing-how-to-add-lit-action-as-an-authmethod-from-the-docs)

# Description

Missing how to add Lit Action as an AuthMethod from the docs.

Have to use `utils.getBytesFromMultihash` to convert ipfsCid from base58 encoding to byte-like. Add it to the docs on this page as a note: https://developer.litprotocol.com/v3/sdk/wallets/auth-methods

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

