### PR TITLE
Update Polyfill with CRA for PKP Ethers

### DIFF
--- a/docs/migration/overview.md
+++ b/docs/migration/overview.md
@@ -260,7 +260,7 @@ module.exports = {
 ```
 
 ### Using Create React App (CRA)
-If you are using CRA you may see the errors related to `stream` `buffer` and `crypto` to being found / handled. You can fix this with the following webpack override
+If you are using CRA you may see the errors related to `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib` and `assert` to being found / handled. You can fix this with the following webpack override
 
 ```javascript
 const webpack = require('webpack'); // Import webpack
@@ -275,6 +275,11 @@ module.exports = {
                 'crypto': require.resolve('crypto-browserify'), // Fallback for 'crypto'
                 'stream': require.resolve('stream-browserify'), // Fallback for 'stream'
                 'buffer': require.resolve('buffer/'), // Add this line
+                'http': require.resolve('stream-http'), // Add this line
+                'https': require.resolve('https-browserify'), // Add this line
+                'url': require.resolve('url/'), // Add this line
+                'zlib': require.resolve('browserify-zlib'), // Add this line
+                'assert': require.resolve('assert/'), // Add this line
             },
         };
 
@@ -301,7 +306,7 @@ module.exports = {
 }; 
 ```
 
-In the above we are replacing `crypto`, `stream`, and `buffer` with browser compatible replacements.
+In the above we are replacing `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib` and `assert` with browser compatible replacements.
 We also modify the default Create React App's `module rules` to include other JavaScript file extensions.
 
 You may need to install [react-app-rewired](https://www.npmjs.com/package/react-app-rewired) to override the webpack confgiuration with the above.


### PR DESCRIPTION
### Fixes Issue: [LIT-2405](https://linear.app/litprotocol/issue/LIT-2405/update-polyfill-with-cra-for-pkp-ethers)

# Description

## Issue

PKP Ethers requires the some polyfills which is missing from the CRA section: https://developer.litprotocol.com/v3/migration/overview/#using-create-react-app-cra

## Solution

Create a new sub-section below it to state the required polyfills and how to do so. Install & add the following to config-overrides.js just as mentioned here: https://developer.litprotocol.com/v3/migration/overview/#using-create-react-app-cra

```js
'http': require.resolve('stream-http'), // Add this line
'https': require.resolve('https-browserify'), // Add this line
'url': require.resolve('url/'), // Add this line
'zlib': require.resolve('browserify-zlib'), // Add this line
'assert': require.resolve('assert/'), // Add this line
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

