### PR TITLE
Formatted params in new lines at Delgating Access to your Capacity Cr…

### DIFF
--- a/docs/sdk/capacity-credits.md
+++ b/docs/sdk/capacity-credits.md
@@ -69,7 +69,7 @@ const { capacityDelegationAuthSig } =
 ```
 To delegate your Rate Limit NFT there are 4 properties to configure:
 
-- `uses` - How many time the delegation may be used
+- `uses` - How many times the delegation may be used
 - `dAppOwnerWallet` - The owner of the wallet as an `ethers Wallet instance`
 - `capacityTokenId` -  The `token identifier` of the Rate Limit NFT
 - `delegateeAddresses` - The wallet addresses which will be delegated to

--- a/docs/sdk/capacity-credits.md
+++ b/docs/sdk/capacity-credits.md
@@ -67,12 +67,12 @@ const { capacityDelegationAuthSig } =
     delegateeAddresses: [secondWalletPKPInfo.ethAddress],
   });
 ```
-To delegate your Rate Limit NFT there are 4 properties to configure
+To delegate your Rate Limit NFT there are 4 properties to configure:
 
-`uses` - How many time the delegation may be used
-`dAppOwnerWallet` - The owner of the wallet as an `ethers Wallet instance`
-`capacityTokenId` -  The `token identifier` of the Rate Limit NFT
-`delegateeAddresses` - The wallet addresses which will be delegated to
+- `uses` - How many time the delegation may be used
+- `dAppOwnerWallet` - The owner of the wallet as an `ethers Wallet instance`
+- `capacityTokenId` -  The `token identifier` of the Rate Limit NFT
+- `delegateeAddresses` - The wallet addresses which will be delegated to
 
 
 ## **Generating Sessions from delegation signature**


### PR DESCRIPTION
### Fixes Issue: [LIT-2399](https://linear.app/litprotocol/issue/LIT-2399/formatting-deligating-access-to-your-capacity-credits-nft-section)

# Description

Formatted Deligating Access to your Capacity Credits NFT section

On https://developer.litprotocol.com/v3/sdk/capacity-credits#deligating-access-to-your-capacity-credits-nft parameters specified can be placed in new line

Trying to update docs for it!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

