### PR TITLE
Added expiration time to SIWE message

### DIFF
--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -131,7 +131,7 @@ async function main() {
   const statement =
     'This is a test statement.  You can put anything you want here.';
     
-  // expirtaion time in ISO 8601 format
+  // expiration time in ISO 8601 format.  This is 7 days in the future, calculated in milliseconds
   const expirationTime = new Date(
     Date.now() + 1000 * 60 * 60 * 24 * 7 * 10000
   ).toISOString();

--- a/docs/sdk/authentication/auth-sig.md
+++ b/docs/sdk/authentication/auth-sig.md
@@ -130,6 +130,12 @@ async function main() {
   const origin = 'https://localhost/login';
   const statement =
     'This is a test statement.  You can put anything you want here.';
+    
+  // expirtaion time in ISO 8601 format
+  const expirationTime = new Date(
+    Date.now() + 1000 * 60 * 60 * 24 * 7 * 10000
+  ).toISOString();
+  
   const siweMessage = new siwe.SiweMessage({
     domain,
     address: address,
@@ -138,6 +144,7 @@ async function main() {
     version: '1',
     chainId: 1,
     nonce,
+    expirationTime,
   });
   const messageToSign = siweMessage.prepareMessage();
   


### PR DESCRIPTION
### Fixes Issue: [LIT-2417](https://linear.app/litprotocol/issue/LIT-2417/add-expirationdate-to-siwe-message)

# Description

This is for Hot Wallet Signing, creating AuthSig in the backend

The nodes will throw the error: `Session key expiration time is not set`

## Fix

```js
// expirtaion time in ISO 8601 format
  const expirationTime = new Date(
    Date.now() + 1000 * 60 * 60 * 24 * 7 * 10000
  ).toISOString();

  const siweMessage = new siwe.SiweMessage({
    domain,
    address: wallet.address,
    statement,
    uri: origin,
    version: '1',
    chainId: '1',
    expirationTime,
  });
```

Trying to update the docs for it!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

