### PR TITLE
remove tags for v3 package usage

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn add @lit-protocol/constants@cayenne
+yarn add @lit-protocol/constants
 yarn update-chains
 git add docs/resources/supported-chains.md

--- a/docs/integrations/aa/pimlico.md
+++ b/docs/integrations/aa/pimlico.md
@@ -37,7 +37,7 @@ This how-to guide walks you through the steps to integrate Lit's OTP sign-in wit
 #### **Installing packages**
 
 ```bash
-npm install stytch @lit-protocol/pkp-ethers@cayenne @lit-protocol/lit-auth-client@cayenne @lit-protocol/auth-helpers@cayenne @lit-protocol/types@cayenne @lit-protocol/lit-node-client-nodejs@cayenne
+npm install stytch @lit-protocol/pkp-ethers @lit-protocol/lit-auth-client @lit-protocol/auth-helpers @lit-protocol/types @lit-protocol/lit-node-client-nodejs
 ```
 
 #### **Make an account with Stytch and get the Project ID and Secret**

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -23,7 +23,7 @@ values={[
 Install the `@lit-protocol/lit-node-client` package, which can be used in both browser and Node environments:
 
 ```sh
-yarn add @lit-protocol/lit-node-client@cayenne
+yarn add @lit-protocol/lit-node-client
 ```
 
 Use the **Lit JS SDK V3**:
@@ -39,7 +39,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client";
 Install the `@lit-protocol/lit-node-client-nodejs`, which is for Node environments only:
 
 ```sh
-yarn add @lit-protocol/lit-node-client-nodejs@@cayenne
+yarn add @lit-protocol/lit-node-client-nodejs
 ```
 
 Use the **Lit JS SDK V3**:

--- a/docs/sdk/serverless-signing/conditional-signing.md
+++ b/docs/sdk/serverless-signing/conditional-signing.md
@@ -22,7 +22,7 @@ The `ethers.utils.arrayify(ethers.utils.keccak256(...)` can be used to convert t
 Installed the latest client on `cayenne`
 
 ```bash
-yarn install @lit-protocol/lit-node-client@cayenne
+yarn install @lit-protocol/lit-node-client
 ```
 
 Set up the Lit Action code to be run on the Lit nodes.

--- a/docs/sdk/serverless-signing/processing-validation.md
+++ b/docs/sdk/serverless-signing/processing-validation.md
@@ -7,7 +7,7 @@ How to generate a [signed Ethereum transaction](https://github.com/LIT-Protocol
 This example relies on the following packages: 
 
 ```jsx
-@lit-protocol/lit-node-client@cayenne
+@lit-protocol/lit-node-client
 @ethersproject/transactions
 @ethersproject/signing-key
 @ethersproject/bytes 
@@ -91,7 +91,7 @@ go();
 ## Generating a Session Key
 
 ```jsx
-@lit-protocol/lit-node-client@cayenne
+@lit-protocol/lit-node-client
 @ethersproject/wallet
 @ethersproject/transactions
 siwe

--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -37,7 +37,7 @@ In the example below, we will write a simple Lit Action that requests a signatur
 Install the latest contracts-sdk on `cayenne`
 
 ```bash
-yarn install @lit-protocol/contracts-sdk@cayenne
+yarn install @lit-protocol/contracts-sdk
 ```
 
 ## Set up the controller
@@ -79,7 +79,7 @@ values={[
 <TabItem value="browser">
 
 ```bash
-yarn add @lit-protocol/lit-node-client@cayenne
+yarn add @lit-protocol/lit-node-client
 ```
 
 </TabItem>
@@ -87,7 +87,7 @@ yarn add @lit-protocol/lit-node-client@cayenne
 <TabItem value="nodejs">
 
 ```bash
-yarn add @lit-protocol/lit-node-client-nodejs@cayenne
+yarn add @lit-protocol/lit-node-client-nodejs
 ```
 
 </TabItem>

--- a/docs/sdk/wallets/minting.md
+++ b/docs/sdk/wallets/minting.md
@@ -11,8 +11,8 @@ You can also use the handy helper contract on Chronicle [here](https://chain.lit
 
 ### Installing the required packages
 ```bash
-yarn add @lit-protocol/lit-auth-client@cayenne
-yarn add @lit-protocol/contracts-sdk@cayenne
+yarn add @lit-protocol/lit-auth-client
+yarn add @lit-protocol/contracts-sdk
 ```
 
 ### Initializing your `LitContract` instance


### PR DESCRIPTION
# Description

removes `cayenne` and `beta` tag usages.
**note** the `alchemy` integration has been left using the `cayenne` tag until we complete the migration needed for main net. 
Tasks can be found here: https://linear.app/litprotocol/project/alchemy-account-kit-intigration-77a92ac5d7f6

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

