### PR TITLE
Added capacity credit NFTs can be minted from the Lit Explorer

### DIFF
--- a/docs/sdk/capacity-credits.md
+++ b/docs/sdk/capacity-credits.md
@@ -14,7 +14,11 @@ For more information on Capacity Credits and network rate limiting see [here](..
 
 ## **Minting Capacity Credits**
 
-In order to increase your rate limit you'll need to mint an `Capacity Credits NFT`. To do so, you can use our `contract-sdk` to mint the NFT. You can download the `contracts-sdk` from `npm` [here](https://www.npmjs.com/package/@lit-protocol/contracts-sdk)
+In order to increase your rate limit, you'll need to mint a `Capacity Credits NFT` on Chronicle - Lit's custom EVM rollup testnet. To do so, you can either use:
+1. The [Lit  Explorer](https://explorer.litprotocol.com/get-credits) or,
+2. Our `contracts-sdk`.
+
+A `Capacity Credits NFT` can be very easily minted from the Lit Explorer. So, here we will show how you can mint it using `contracts-sdk`. You can download the `contracts-sdk` from `npm` [here](https://www.npmjs.com/package/@lit-protocol/contracts-sdk).
 
 You’ll also need some 'testLPX' tokens for minting. These are test tokens that hold no real value and should only be used to pay for usage on Habanero. `testLPX` should only be claimed from the verified faucet, linked [here](https://faucet.litprotocol.com/).
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.1.0",
     "@docusaurus/plugin-google-analytics": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
-    "@lit-protocol/constants": "^3.1.4",
+    "@lit-protocol/constants": "^3.2.1",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,43 +2242,43 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lit-protocol/accs-schemas@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.3.tgz#fdcabd16b78df5b065e8ea581af7ba21eccf7182"
-  integrity sha512-hjdJzeHHRABnelu3dZVQFEJUVdtJ9bs7in6uknvWonhTgr4N2m4uMMmYSMGMLXFBpMC53F8V3iF47KxZllCHtQ==
+"@lit-protocol/accs-schemas@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.6.tgz#a2dd4677bdfe33fd1a45b8f6919d1eff92633012"
+  integrity sha512-/NIZkAN+kgAarWefBX1a4DiNerUtv8JOdQmqUo45cnlDp89X9HkiK+8gm9z2p9gojtvxMqqId7wW8J8NHXVRDg==
   dependencies:
     ajv "^8.12.0"
 
-"@lit-protocol/auth-helpers@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.1.4.tgz#8e263e76f433acb0a63cb1ca12f5b75728384b44"
-  integrity sha512-Bg9SSosfS6uSvot8ewFRcTQm8rpTdOtCYXSrmIUcd7tb810F4FDslptlour+Q0fByCjIqFdOwipeznk4EDDjmw==
+"@lit-protocol/auth-helpers@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.2.1.tgz#7f4c47a608221316ccd6e65bd634e03dbc02f859"
+  integrity sha512-nkuEifffHbfgQ3M9dSnSyP+sE+JN2vNrz6cLvpPO/gmDldL4c5KebPHUNeEa+LSxuaXLo5G46RsM7pBcStUrpw==
   dependencies:
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/constants@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.1.4.tgz#cf55dc677c3cd9abbe5ddeee10270d5df599ad77"
-  integrity sha512-3aXIuea9SB5UfRbVgn5CxFnDeQe9hnoYE8r0KMq71skKt7d4AavEmVm/kIzCR7dWibbnPLdlgqBVqrGRh3S9/g==
+"@lit-protocol/constants@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.2.1.tgz#c78bd37bfd6acc568cf18b97aac7685a926aaa74"
+  integrity sha512-gYXLpSBsFHZsS8OTjdKdZYjuWbOemgO/ujKX479TBl7nPvit41Xi+EeyAqTaE27qDepZ7Fi2jBGrlovI9alROw==
   dependencies:
-    "@lit-protocol/accs-schemas" "0.0.3"
-    "@lit-protocol/auth-helpers" "3.1.4"
-    "@lit-protocol/types" "3.1.4"
+    "@lit-protocol/accs-schemas" "0.0.6"
+    "@lit-protocol/auth-helpers" "3.2.1"
+    "@lit-protocol/types" "3.2.1"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/types@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.1.4.tgz#18f23a09e3aa172b1123357b43081987567a907c"
-  integrity sha512-R2V/3+DLLhrriweTc1n032PqB0TszYnNJs03sEuvIy2hkIoTunwUHdLKw5glaRRzTIZRimUBmJgo/ZLQa2pkiQ==
+"@lit-protocol/types@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.2.1.tgz#b0e63988663a98d06a6fcbdb9b0694e7b10ada98"
+  integrity sha512-fnPtXTfvXqU2dvyaT4wnBb31V3B3EaZQfueKbHziloif8N2nX8ApJd0X/v2fae5yzuXcPaCfC9oyIUsQIJIQ+g==
   dependencies:
-    "@lit-protocol/accs-schemas" "0.0.3"
-    "@lit-protocol/auth-helpers" "3.1.4"
+    "@lit-protocol/accs-schemas" "0.0.6"
+    "@lit-protocol/auth-helpers" "3.2.1"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"


### PR DESCRIPTION
### Fixes Issue: [LIT-2535](https://linear.app/litprotocol/issue/LIT-2535/capacity-credits-can-be-minted-from-the-explorer)

# Description

Capacity credits are much simpler to be minted from the Lit PKP Explorer but haven't mentioned this in the docs

Here - https://developer.litprotocol.com/v3/sdk/capacity-credits/

Reference - https://www.notion.so/litprotocol/Simplify-Mainnet-Migration-abb502a527144ec5b2aecc63d247215f#8b51454a526d48459b6927987467d813

Trying to update the docs for it!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary