### PR TITLE
Example to decrypt from old and encrypt in new network

### DIFF
--- a/docs/network/migration-guide.md
+++ b/docs/network/migration-guide.md
@@ -43,11 +43,118 @@ We have an example script here that will perform the re-minting for you: https:/
 
 ## Performing re-encryption
 
-Re-encryption is simply, decrypting the content, then encrypting it again.  In the case of a migration from an old Lit Network to Habanero, you would connect to the old network, decrypt the user’s data, and then connect to Habanero and encrypt it again.
+Re-encryption is simply, decrypting the content, then encrypting it again. The v3 SDK of the encryption system introduces significant enhancements compared to v2 SDK. It employs a more intricate yet secure method of encryption and decryption, utilizing hashes and a comprehensive set of parameters to bolster security and integrity. 
+
+Unlike v2, both encryption and decryption processes in v3 explicitly rely on the `litNodeClient` showcasing a deeper integration with the Lit network's infrastructure. Additionally, v3 incorporates a data hash (`dataToEncryptHash`) during encryption, allowing for additional validation and integrity checks, which were absent in v2. Furthermore, v3 transitions from using basic types (like `string`) to structured request and response objects, like `EncryptStringRequest` and `DecryptRequest`, indicates a shift towards more detailed and configurable encryption/decryption operations to cater to diverse use cases.
+
+In the case of a migration from an old Lit Network to Habanero, you would follow these steps to learn how to decrypt and re-encrypt your data:
+
+### 1. Connect to the old network using Lit Js SDK V2
+```js
+class LitV2 {
+  private litNodeClient;
+
+  async connect() {
+    const client = new LitJsSdk.LitNodeClient();
+    await client.connect();
+    this.litNodeClient = client;
+  }
+}
+
+export default new Lit();
+```
+### 2. Decrypt the user’s data using old network
+```js
+// Lit Js SDK V2 decryption example
+async decrypt(encryptedString, encryptedSymmetricKey) {
+  if (!this.litNodeClient) {
+    await this.connect();
+  }
+
+  const authSig = await LitJsSdk.checkAndSignAuthMessage({ chain: "ethereum" });
+  const accessControlConditions = [
+    {
+      contractAddress: "",
+      standardContractType: "",
+      chain: "ethereum",
+      method: "eth_getBalance",
+      parameters: [":userAddress", "latest"],
+      returnValueTest: {
+        comparator: ">=",
+        value: "1000000000000", // 0.000001 ETH
+      },
+    },
+  ];
+
+  const symmetricKey = await this.litNodeClient.getEncryptionKey({
+    accessControlConditions,
+    toDecrypt: encryptedSymmetricKey,
+    chain: "ethereum",
+    authSig
+  });
+  const decryptedString = await LitJsSdk.decryptString(
+    encryptedString,
+    symmetricKey
+  );
+
+  return { decryptedString };
+}
+```
+### 3. Connect to `Habanero` or `Manzano` and encrypt it again
+```js
+class LitV3 {
+  private litNodeClient;
+
+  async connect() {
+    const client = new LitJsSdk.LitNodeClient({
+         litNetwork: "manzano",
+    });
+    await client.connect();
+    this.litNodeClient = client;
+  }
+
+  async encrypt(message) {
+    if (!this.litNodeClient) {
+      await this.connect();
+    }
+  
+    const authSig = await LitJsSdk.checkAndSignAuthMessage({ chain: 'ethereum' });
+    const accessControlConditions = [
+      {
+        contractAddress: "",
+        standardContractType: "",
+        chain: "ethereum",
+        method: "eth_getBalance",
+        parameters: [":userAddress", "latest"],
+        returnValueTest: {
+          comparator: ">=",
+          value: "1000000000000", // 0.000001 ETH
+        },
+      },
+    ];
+
+    const { ciphertext, dataToEncryptHash } = await LitJsSdk.encryptString(
+      {
+        accessControlConditions,
+        authSig,
+        chain: 'ethereum',
+        dataToEncrypt: message,
+      },
+      litNodeClient,
+    );
+  
+    return {
+      ciphertext,
+      dataToEncryptHash,
+    };
+  }
+}
+
+export default new Lit();
+
+```
 
 Since in many cases, only the end user themselves can actually decrypt the content, you may adopt a system where you migrate each user when they use the system. You may start sending traffic from new users that *don’t* have any existing content to Habanero, immediately.  You may want to track which network each user is using in your user DB, and then upon login, look this up to decide which network to talk to.
-
-You may follow the docs on [encryption](../sdk/access-control/encryption.md) to learn how to decrypt and re-encrypt your data. 
 
 ## Installing and Initializing the Lit SDK
 

--- a/docs/network/migration-guide.md
+++ b/docs/network/migration-guide.md
@@ -45,6 +45,8 @@ We have an example script here that will perform the re-minting for you: https:/
 
 Re-encryption is simply, decrypting the content, then encrypting it again. The v3 SDK of the encryption system introduces significant enhancements compared to v2 SDK. It employs a more intricate yet secure method of encryption and decryption, utilizing hashes and a comprehensive set of parameters to bolster security and integrity. 
 
+The Lit network employs an ID-based encryption method allowing only users who meet specific identity criteria to decrypt data. This process involves the use of the BLS network signature as a decryption key, which is generated based on access control conditions and private data. Encryption occurs client-side, requiring minimal network interaction—just a single round for decryption to gather necessary signature shares. Read more about ID based encryption [here](../sdk/access-control/encryption/#how-does-id-encrypt-work).
+
 Unlike v2, both encryption and decryption processes in v3 explicitly rely on the `litNodeClient` showcasing a deeper integration with the Lit network's infrastructure. Additionally, v3 incorporates a data hash (`dataToEncryptHash`) during encryption, allowing for additional validation and integrity checks, which were absent in v2. Furthermore, v3 transitions from using basic types (like `string`) to structured request and response objects, like `EncryptStringRequest` and `DecryptRequest`, indicates a shift towards more detailed and configurable encryption/decryption operations to cater to diverse use cases.
 
 In the case of a migration from an old Lit Network to Habanero, you would follow these steps to learn how to decrypt and re-encrypt your data:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.1.0",
     "@docusaurus/plugin-google-analytics": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
-    "@lit-protocol/constants": "^3.1.4",
+    "@lit-protocol/constants": "^3.2.1",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,43 +2242,43 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lit-protocol/accs-schemas@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.3.tgz#fdcabd16b78df5b065e8ea581af7ba21eccf7182"
-  integrity sha512-hjdJzeHHRABnelu3dZVQFEJUVdtJ9bs7in6uknvWonhTgr4N2m4uMMmYSMGMLXFBpMC53F8V3iF47KxZllCHtQ==
+"@lit-protocol/accs-schemas@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/accs-schemas/-/accs-schemas-0.0.6.tgz#a2dd4677bdfe33fd1a45b8f6919d1eff92633012"
+  integrity sha512-/NIZkAN+kgAarWefBX1a4DiNerUtv8JOdQmqUo45cnlDp89X9HkiK+8gm9z2p9gojtvxMqqId7wW8J8NHXVRDg==
   dependencies:
     ajv "^8.12.0"
 
-"@lit-protocol/auth-helpers@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.1.4.tgz#8e263e76f433acb0a63cb1ca12f5b75728384b44"
-  integrity sha512-Bg9SSosfS6uSvot8ewFRcTQm8rpTdOtCYXSrmIUcd7tb810F4FDslptlour+Q0fByCjIqFdOwipeznk4EDDjmw==
+"@lit-protocol/auth-helpers@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.2.1.tgz#7f4c47a608221316ccd6e65bd634e03dbc02f859"
+  integrity sha512-nkuEifffHbfgQ3M9dSnSyP+sE+JN2vNrz6cLvpPO/gmDldL4c5KebPHUNeEa+LSxuaXLo5G46RsM7pBcStUrpw==
   dependencies:
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/constants@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.1.4.tgz#cf55dc677c3cd9abbe5ddeee10270d5df599ad77"
-  integrity sha512-3aXIuea9SB5UfRbVgn5CxFnDeQe9hnoYE8r0KMq71skKt7d4AavEmVm/kIzCR7dWibbnPLdlgqBVqrGRh3S9/g==
+"@lit-protocol/constants@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.2.1.tgz#c78bd37bfd6acc568cf18b97aac7685a926aaa74"
+  integrity sha512-gYXLpSBsFHZsS8OTjdKdZYjuWbOemgO/ujKX479TBl7nPvit41Xi+EeyAqTaE27qDepZ7Fi2jBGrlovI9alROw==
   dependencies:
-    "@lit-protocol/accs-schemas" "0.0.3"
-    "@lit-protocol/auth-helpers" "3.1.4"
-    "@lit-protocol/types" "3.1.4"
+    "@lit-protocol/accs-schemas" "0.0.6"
+    "@lit-protocol/auth-helpers" "3.2.1"
+    "@lit-protocol/types" "3.2.1"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/types@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.1.4.tgz#18f23a09e3aa172b1123357b43081987567a907c"
-  integrity sha512-R2V/3+DLLhrriweTc1n032PqB0TszYnNJs03sEuvIy2hkIoTunwUHdLKw5glaRRzTIZRimUBmJgo/ZLQa2pkiQ==
+"@lit-protocol/types@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.2.1.tgz#b0e63988663a98d06a6fcbdb9b0694e7b10ada98"
+  integrity sha512-fnPtXTfvXqU2dvyaT4wnBb31V3B3EaZQfueKbHziloif8N2nX8ApJd0X/v2fae5yzuXcPaCfC9oyIUsQIJIQ+g==
   dependencies:
-    "@lit-protocol/accs-schemas" "0.0.3"
-    "@lit-protocol/auth-helpers" "3.1.4"
+    "@lit-protocol/accs-schemas" "0.0.6"
+    "@lit-protocol/auth-helpers" "3.2.1"
     ethers "^5.7.1"
     jszip "^3.10.1"
     siwe "^2.0.5"


### PR DESCRIPTION
### Fixes Issue: [LIT-2534](https://linear.app/litprotocol/issue/LIT-2534/example-to-decrypt-from-old-networks-and-encrypt-in-the-newer-ones)

# Description

We now use ID encryption which is different from Jalapeno & Serrano

Devs find it difficult to understand how to do this migration

Create an example for doing so explaining each step & differences between the two encryption schemes

Trying to update the docs for it!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary