### PR TITLE
fix: Add jszip polyfill

### DIFF
--- a/docs/migration/overview.md
+++ b/docs/migration/overview.md
@@ -276,7 +276,7 @@ module.exports = {
 ```
 
 ### Using Create React App (CRA)
-If you are using CRA you may see the errors related to `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib` and `assert` to being found / handled. You can fix this with the following webpack override
+If you are using CRA you may see the errors related to `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib`, `jszip` and `assert` to being found / handled. You can fix this with the following webpack override
 
 ```javascript
 const webpack = require('webpack'); // Import webpack
@@ -295,6 +295,7 @@ module.exports = {
                 'https': require.resolve('https-browserify'), // Add this line
                 'url': require.resolve('url/'), // Add this line
                 'zlib': require.resolve('browserify-zlib'), // Add this line
+                'jszip': require.resolve('jszip/'), // Add this line
                 'assert': require.resolve('assert/'), // Add this line
             },
         };
@@ -322,7 +323,7 @@ module.exports = {
 }; 
 ```
 
-In the above we are replacing `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib` and `assert` with browser compatible replacements.
+In the above we are replacing `stream`, `buffer`, `crypto`, `http`, `https`, `url`, `zlib`, `jszip` and `assert` with browser compatible replacements.
 We also modify the default Create React App's `module rules` to include other JavaScript file extensions.
 
 You may need to install [react-app-rewired](https://www.npmjs.com/package/react-app-rewired) to override the webpack confgiuration with the above.


### PR DESCRIPTION
# Description

`Error: Cannot find module 'jszip/dist/jszip.js'` in SDK v3.2.3

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

General
- [X] I have performed a self-review of my code
- [X] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [X] I have checked the additions are concise
- [X] Language is consistent with existing documentation

# Others

Was this error restricted to CRA or it was also in an NodeJS app? @Aaryan-R-S 


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

