### PR TITLE
fix(keyClaim): add calculating key id section

### DIFF
--- a/docs/resources/supported-chains.md
+++ b/docs/resources/supported-chains.md
@@ -111,6 +111,8 @@ You can learn more about compatible chains [here.](http://ethanfast.com/top-cryp
 
 - solanaTestnet
 
+- verifyTestnet
+
 - waevEclipseDevnet
 
 - waevEclipseTestnet

--- a/docs/sdk/serverless-signing/key-claiming.md
+++ b/docs/sdk/serverless-signing/key-claiming.md
@@ -16,16 +16,26 @@ Lit Actions have their own support for [claiming](../wallets/claimable-keys/intr
 Instead of pre-authenticating the `access token` within an `Authentication Method`, claiming in a Lit Action allows you to define your own `userId` and use the Actions `IPFS CID` to form the `key identifier` through your own user identifier. This doesn't require a pre-authentication step which allows you to set up your own claims to then be routed on-chain with our `contract-sdk`.
 
 ## Example
+Here is an example of how to claim a key using the Lit SDK and then mint a claim using the `contract-sdk`.
+
+### Calculating your key id
+You can create key id by taking the keccak256 hash of the `theIPFSIdOfYourLitAction_yourUserId` where `theIPFSIdOfYourLitAction` is the IPFS CID of your lit action that will be used for claiming and then `yourUserId` is the user id of the user.  You need to separate these items with an `_` in the string.
+
+```jsx
+const keyId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("theIPFSIdOfYourLitAction_yourUserId"))
+```
+
+### Minting a claim
 
 ```jsx
   const res = await client.executeJs({
     authSig,
     code: `(async () => {
-      Lit.Actions.claimKey({keyId: userId});
+      Lit.Actions.claimKey({keyId});
     })();`,
     authMethods: [],
     jsParams: {
-        userId: 'foo'
+        keyId
     },
   });
 
@@ -33,7 +43,7 @@ Instead of pre-authenticating the `access token` within an `Authentication Metho
   let tx = await contractClient.pkpNftContract.write.claimAndMint(2, res.claims['foo'].derivedKeyId, res.claims['foo'].signatures);
 ```
 
-### adding an auth method when minting a claim
+### Adding an auth method when minting a claim
 ```jsx
   const authMethod = {
     authMethodType: AuthMethodType.EthWallet,
@@ -42,13 +52,15 @@ Instead of pre-authenticating the `access token` within an `Authentication Metho
 
   const authMethodId = LitAuthClient.getAuthMethodId(authMethod);
 
+  const keyId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("theIPFSIdOfYourLitAction_yourUserId"))
+
   const res = await client.executeJs({
     authSig,
     code: `(async () => {
-      Lit.Actions.claimKey({keyId: userId});
+      Lit.Actions.claimKey({keyId});
     })();`,
     jsParams: {
-        userId: 'foo'
+        keyId
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/core": "2.1.0",
     "@docusaurus/plugin-google-analytics": "^2.1.0",
     "@docusaurus/preset-classic": "2.1.0",
-    "@lit-protocol/constants": "^3.2.3",
+    "@lit-protocol/constants": "^4.1.1",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,37 +2249,39 @@
   dependencies:
     ajv "^8.12.0"
 
-"@lit-protocol/auth-helpers@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-3.2.3.tgz#03aeba16389088bdebf89a8c8a8ac202e7e2850b"
-  integrity sha512-ywfTE0OQho76wmPHMyTGld5HZJs4oX+JVs2W/xyarQL9fYCe5Vf9BkA0ozTG83AzzgioH5Z5kDU0tNzfLobsqQ==
+"@lit-protocol/auth-helpers@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/auth-helpers/-/auth-helpers-4.1.1.tgz#8bb6ec309db2541697b993b06918bf2816bd90bc"
+  integrity sha512-N1wzaDwsGhfeOlirb3KgubsvqRZFQFGkVgFRQl4wyNshueyaY2VwVTDj869pf2DVKapzC17C8OZfE2r10j3WpA==
   dependencies:
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
 
-"@lit-protocol/constants@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-3.2.3.tgz#a980626960550cb31d8a6572ad65095d69dbbca9"
-  integrity sha512-HVXb4hhtJlQoj1obZ8mnwRb7xM2vrvs0cdcVtI/qd1Kani2DH6cXqjdxulC06Mgwu8WlBlchpdTZQsmjIHz4LQ==
+"@lit-protocol/constants@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/constants/-/constants-4.1.1.tgz#f0a16e475d17f3bbf43c3249db3bba8fb28e12d7"
+  integrity sha512-FmJEAweMGvOnQrWh4B3Bxdt2EdWKjwIXZp3McSlCbAdVvqTumj3qRrCqmPummJ1ajelxePKuwHZ17xv0yTnJMg==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@lit-protocol/accs-schemas" "0.0.6"
-    "@lit-protocol/auth-helpers" "3.2.3"
-    "@lit-protocol/types" "3.2.3"
+    "@lit-protocol/auth-helpers" "4.1.1"
+    "@lit-protocol/types" "4.1.1"
     ethers "^5.7.1"
+    jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
 
-"@lit-protocol/types@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-3.2.3.tgz#6906ccb092b9333db53d58f252d4fe3cf2a095f0"
-  integrity sha512-dZeAIoAFO0npdpIkBTBmlpQiay/mwtIN2+1c4YfQ7KPGXFzfOuM9xxT2B8cAU0+3bdHVjxLD+ixGoaE46eX4yw==
+"@lit-protocol/types@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/types/-/types-4.1.1.tgz#f0056d2b80e987bb4b4ec168d0cf980094bbd893"
+  integrity sha512-d0oq6JU4Ls0n7aJ/7duH3y9gXaWO3++1RaJeKvwRkfpRLKCsfLNCl+yfvcRD+LHSADeMYTN1b99dLY9ao+5u7Q==
   dependencies:
     "@ethersproject/abstract-provider" "5.7.0"
     "@lit-protocol/accs-schemas" "0.0.6"
-    "@lit-protocol/auth-helpers" "3.2.3"
+    "@lit-protocol/auth-helpers" "4.1.1"
     ethers "^5.7.1"
+    jszip "^3.10.1"
     siwe "^2.0.5"
     siwe-recap "0.0.2-alpha.0"
     tslib "^2.3.0"
@@ -5565,6 +5567,11 @@ image-size@^1.0.1:
   dependencies:
     queue "6.0.2"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 immer@^9.0.7:
   version "9.0.21"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
@@ -6077,6 +6084,16 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -6113,6 +6130,13 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lilconfig@^2.0.3:
   version "2.1.0"
@@ -6732,6 +6756,11 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
+
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -7486,7 +7515,7 @@ react@^17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-readable-stream@^2.0.1:
+readable-stream@^2.0.1, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==


### PR DESCRIPTION
### Fixes Issue: [LIT-2700](https://linear.app/litprotocol/issue/LIT-2700/add-a-section-on-calculating-key-id)

# Description

Add a section on calculating your key id to this page: https://developer.litprotocol.com/v3/sdk/serverless-signing/key-claiming in a section called "calculating your key id".

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

