### PR TITLE
fix(keyClaim): fix parameters to executeJs in example

### DIFF
--- a/docs/sdk/serverless-signing/key-claiming.md
+++ b/docs/sdk/serverless-signing/key-claiming.md
@@ -31,11 +31,11 @@ const keyId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("theIPFSIdOfYourLi
   const res = await client.executeJs({
     authSig,
     code: `(async () => {
-      Lit.Actions.claimKey({keyId});
+      Lit.Actions.claimKey({keyId: userId});
     })();`,
     authMethods: [],
     jsParams: {
-        keyId
+        userId: 'foo'
     },
   });
 
@@ -57,10 +57,10 @@ const keyId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("theIPFSIdOfYourLi
   const res = await client.executeJs({
     authSig,
     code: `(async () => {
-      Lit.Actions.claimKey({keyId});
+      Lit.Actions.claimKey({keyId: userId});
     })();`,
     jsParams: {
-        keyId
+        userId: 'foo'
     },
   });
 


### PR DESCRIPTION
### Fixes Issue: [LIT-2751](https://linear.app/litprotocol/issue/LIT-2751/correcting-lit-actions-doc)

# Description

It's not clear from the docs where we're getting 'foo' from:
```js
const res = await client.executeJs({
    authSig,
    code: (async () => {
      Lit.Actions.claimKey({keyId});
    })();,
    authMethods: [],
    jsParams: {
        keyId
    },
  });

  let client = new LitContracts(signer: "<your pkp wallet or other signer>");
  let tx = await contractClient.pkpNftContract.write.claimAndMint(2, res.claims['foo'].derivedKeyId, res.claims['foo'].signatures);
```
at https://developer.litprotocol.com/v3/sdk/serverless-signing/key-claiming

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Introducing new feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Link to the relevant updated sections in the Netlify preview

- [ ] Link 1: [description of change]
- [ ] Link 2: [...]

# Checklist:

General
- [ ] I have performed a self-review of my code
- [ ] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ ] I have checked the additions are concise
- [ ] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ ] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

