### PR TITLE
Missing space in package import code example

### DIFF
--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -38,7 +38,7 @@ If you are using `NodeJS` you should install `@lit-protocol/lit-node-client-node
 Use the **Lit JS SDK V4**:
 
 ```jsx
-import * as LitJsSdkfrom "@lit-protocol/lit-node-client";
+import * as LitJsSdk from "@lit-protocol/lit-node-client";
 
 ```
 

--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -53,7 +53,7 @@ Within a file (in the Lit example repos it will likely be called `lit.js`), set
 `client.connect()` will return a promise that resolves when you are connected to the Lit Network.
 
 ```jsx
-const client =new LitJsSdk.LitNodeClient({
+const client = new LitJsSdk.LitNodeClient({
   litNetwork: 'habanero',
 });
 


### PR DESCRIPTION
This PR is merging into `main`, not sure if we prefer merging into a different branch

Missing a space in the [import code example](https://developer.litprotocol.com/v3/sdk/access-control/quick-start#install-and-import-the-lit-sdk):

<img width="729" alt="image" src="https://github.com/LIT-Protocol/docs/assets/20375610/b93f4b89-08ab-44d0-98b4-14c7f3ea314e">

<img width="734" alt="image" src="https://github.com/LIT-Protocol/docs/assets/20375610/2488c74c-ae0c-45d2-9ecc-fb6ee28323c3">
