### PR TITLE
fix: typo severless -> serverless

### DIFF
--- a/docs/sdk/serverless-signing/conditional-signing.md
+++ b/docs/sdk/serverless-signing/conditional-signing.md
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 ## Prerequisites
 
 - Familiarity with JavaScript
-- Basic understanding of [severless signing](../serverless-signing/quick-start.md)
+- Basic understanding of [serverless signing](../serverless-signing/quick-start.md)
 
 ## Overview
 Lit Actions inherit the powerful condition checking that Lit Protocol utilizes for Access Control. This means that you can easily check any on-chain condition inside a Lit Action, which can be useful for generating proofs. This system can be used to uphold the integrity of data on the open web, in its function as a decentralized notary.

--- a/docs/sdk/serverless-signing/fetch.md
+++ b/docs/sdk/serverless-signing/fetch.md
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 ## Prerequisites
 
 - Familiarity with JavaScript
-- Basic understanding of [severless signing](../serverless-signing/quick-start.md)
+- Basic understanding of [serverless signing](../serverless-signing/quick-start.md)
 
 ## Overview
 Unlike traditional smart contract ecosystems, Lit Actions can natively talk to the external world. This is useful for things like fetching data from the web, or sending API requests to other services.

--- a/docs/sdk/serverless-signing/key-claiming.md
+++ b/docs/sdk/serverless-signing/key-claiming.md
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 ## Prerequisites
 
 - Familiarity with JavaScript
-- Basic understanding of [severless signing](../serverless-signing/quick-start.md)
+- Basic understanding of [serverless signing](../serverless-signing/quick-start.md)
 
 ## Overview
 

--- a/docs/sdk/serverless-signing/overview.md
+++ b/docs/sdk/serverless-signing/overview.md
@@ -11,7 +11,7 @@ Using Lit Actions in production IS now supported on the [Habanero Mainnet](../..
 
 Blockchains like Ethereum have smart contracts that let developers encode logic to change that state. As a key management network, Lit provides a method that allows developers to encode logic that dictates signing.
 
-Severless signing (AKA Lit Actions), are JavaScript programs that can be used to specify signing and authentication logic for Programmable Key Pairs (PKPs). When used in conjunction with PKPs, Lit Actions are serverless functions with their own private key-pair that can be used to write data to blockchains and other state machines.
+Serverless signing (AKA Lit Actions), are JavaScript programs that can be used to specify signing and authentication logic for Programmable Key Pairs (PKPs). When used in conjunction with PKPs, Lit Actions are serverless functions with their own private key-pair that can be used to write data to blockchains and other state machines.
 
 A simple example is a Lit Action and associated PKP that checks if a number is prime. The PKP gets [atomically](https://github.com/LIT-Protocol/js-sdk/blob/70a041a97b56ba1a75724ba2cd56952b622e8a7f/packages/contracts-sdk/src/abis/PKPNFT.ts#L376) assigned to the Lit Action, only returning a signature if the required conditions are met (in this case, if a prime number is inputted). Each node will execute the Lit Action in parallel and verify that it meets the required conditions. If it does, each node independently provisions a signing share to the requesting client. Only after more than two-thirds of these shares have been collected is  the complete signature returned.
 


### PR DESCRIPTION
# Description

This PR corrects the typo "severless" to the correct form of "serverless."