### PR TITLE
Update documentation : replace '...' accessToken by 'JSON.stringify(authSig)'

### DIFF
--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -254,7 +254,7 @@ import { AuthMethodScope, AuthMethodType } from '@lit-protocol/constants';
 
 const authMethod = {
   authMethodType: AuthMethodType.EthWallet,
-  accessToken: '...',
+  accessToken: JSON.stringify(authSig),
 };
 
 const mintInfo = await contractClient.mintWithAuth({

--- a/docs/sdk/wallets/minting-methods/mint-via-contracts.md
+++ b/docs/sdk/wallets/minting-methods/mint-via-contracts.md
@@ -37,7 +37,7 @@ import { AuthMethodScope, AuthMethodType } from '@lit-protocol/constants';
 
 const authMethod = {
   authMethodType: AuthMethodType.EthWallet,
-  accessToken: '...',
+  accessToken: JSON.stringify(authSig),
 };
 
 const mintInfo = await contractClient.mintWithAuth({

--- a/docs/sdk/wallets/quick-start.md
+++ b/docs/sdk/wallets/quick-start.md
@@ -255,7 +255,7 @@ import { AuthMethodScope, AuthMethodType } from '@lit-protocol/constants';
 
 const authMethod = {
   authMethodType: AuthMethodType.EthWallet,
-  accessToken: '...',
+  accessToken: JSON.stringify(authSig),
 };
 
 const mintInfo = await contractClient.mintWithAuth({


### PR DESCRIPTION
# Description

In : 
- https://developer.litprotocol.com/v3/sdk/wallets/quick-start
- https://developer.litprotocol.com/v3/sdk/serverless-signing/quick-start

The `accessToken` in the `authMethod` is defined as : "...". 

This code generates an error.

I assume the correct version is : `accessToken: JSON.stringify(authSig),`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [x] Language is consistent with existing documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)
