### PR TITLE
#31 - Add an info for users who wants to use vite with the contract-sdk

### DIFF
--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -370,6 +370,8 @@ OR
 npm i @lit-protocol/contracts-sdk
 ```
 
+ps: the `contracts-sdk` is actually facing issues with vite's config with yarn and pnpm, you can switch to bun as a quick fix or follow the [issue on github](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31)
+
 The next step is to initialize a signer. This should be a wallet controlled by your application and the same wallet you’ll use to mint the Capacity Credit NFT:
 
 ```jsx

--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -99,6 +99,8 @@ yarn add @lit-protocol/contracts-sdk
 yarn add @lit-protocol/lit-auth-client
 ```
 
+ps: the `contracts-sdk` is actually facing issues with vite's config with yarn and pnpm, you can switch to bun as a quick fix or follow the [issue on github](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31)
+
 ### Set up a controller wallet
 
 To initialize a LitContracts client you need an Ethereum Signer. This can be a standard Ethereum wallet (ethers) or a PKP (more info on the latter **[here](https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/lit-auth-methods/add-remove-auth-methods)**). Here, we're going to use a standard Ethereum wallet.

--- a/docs/sdk/wallets/minting-methods/mint-via-contracts.md
+++ b/docs/sdk/wallets/minting-methods/mint-via-contracts.md
@@ -16,6 +16,8 @@ yarn add @lit-protocol/lit-auth-client
 yarn add @lit-protocol/contracts-sdk
 ```
 
+ps: the `contracts-sdk` is actually facing issues with vite's config with yarn and pnpm, you can switch to bun as a quick fix or follow the [issue on github](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31)
+
 ## Initializing your `LitContract` instance
 ```js
 import { LitContracts } from '@lit-protocol/contracts-sdk';

--- a/docs/sdk/wallets/minting-methods/mint-via-multiple-auth-methods.md
+++ b/docs/sdk/wallets/minting-methods/mint-via-multiple-auth-methods.md
@@ -176,6 +176,8 @@ yarn add @lit-protocol/lit-auth-client
 yarn add @lit-protocol/contracts-sdk
 ```
 
+ps: the `contracts-sdk` is actually facing issues with vite's config with yarn and pnpm, you can switch to bun as a quick fix or follow the [issue on github](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31)
+
 ### Setting up the `LitContracts` client
 
 First, configure your Ethereum provider and the controller wallet. Initialize the LitContracts client with the appropriate network settings.

--- a/docs/sdk/wallets/quick-start.md
+++ b/docs/sdk/wallets/quick-start.md
@@ -98,6 +98,8 @@ yarn add @lit-protocol/contracts-sdk
 yarn add @lit-protocol/lit-auth-client
 ```
 
+ps: the `contracts-sdk` is actually facing issues with vite's config with yarn and pnpm, you can switch to bun as a quick fix or follow the [issue on github](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31)
+
 ### Set up a controller wallet
 
 To initialize a LitContracts client you need an Ethereum Signer. This can be a standard Ethereum wallet (ethers) or a PKP (more info on the latter **[here](https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/lit-auth-methods/add-remove-auth-methods)**). Here, we're going to use a standard Ethereum wallet.


### PR DESCRIPTION
# Description

Inform the users that the contract-sdk is not actually working with vite and provide a bypass with bun.

It provides a quickfix for the issue [#31](https://github.com/LIT-Protocol/Issues-and-Reports/issues/31), [#19](https://github.com/LIT-Protocol/Issues-and-Reports/issues/19) and [#22](https://github.com/LIT-Protocol/Issues-and-Reports/issues/22).

## Type of change

Please delete options that are not relevant.

- [x] Documentation update waiting for a complete fix

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [x] Language is consistent with existing documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [x] included a beginner friendly explanation
- [ ] included a basic technical introduction and code sample
- [ ] new terms are defined, both in relevant new pages and in the glossary

