### PR TITLE
Update and rename v4-sdk.md to latest.md

### DIFF
--- a/docs/api-reference/latest.md
+++ b/docs/api-reference/latest.md
@@ -1,6 +1,6 @@
 import FeedbackComponent from "@site/src/pages/feedback.md";
 
-# SDK v4.x.x
+# Lit js-sdk API Reference (Latest)
 
 The most recent API docs can be viewed [here](https://lit-js-sdk-v3-api-docs.vercel.app/).
 


### PR DESCRIPTION
Changes docs section title from v4 to latest, updates title within the doc page to reference latest sdk doc link.
