### PR TITLE
Add capacity credits note

### DIFF
--- a/docs/sdk/migrations/6.0.0.md
+++ b/docs/sdk/migrations/6.0.0.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 The most significant change in v6 is the combination of `authSig` and `sessionSigs`. In most functions, the client-side generated `authSig` will no longer be accepted as an argument, as seen in commonly used functions like `executeJs` and `pkpSign`. Instead, it will be used to generate `sessionSigs` to authenticate with the Lit nodes.
 
-::: note
+:::note
 The migration from `authSig` to `sessionSigs` will not effect `encryption`/`decryption` features within [`Access Control Conditions`](./../access-control/intro.md)
 Only features related to our [PKPs](./../wallets/intro.md) will be requiring session authentication.
 :::
@@ -472,6 +472,10 @@ const authSig = await generateAuthSig({
 #### createCapacityDelegationAuthSig
 
 There has been some confusion on the parameters for `createCapacityDelegationAuthSig`, particularly `capacityTokenId`, `delegateeAddresses`, and `uses` when delegating [capacity credits](../serverless-signing/quick-start.md).
+
+:::note
+On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as look as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` or **not** valid on the `cayenne` network.
+:::
 
 Below is a table detailing the expected behaviors of each:
 

--- a/docs/sdk/migrations/6.0.0.md
+++ b/docs/sdk/migrations/6.0.0.md
@@ -474,7 +474,7 @@ const authSig = await generateAuthSig({
 There has been some confusion on the parameters for `createCapacityDelegationAuthSig`, particularly `capacityTokenId`, `delegateeAddresses`, and `uses` when delegating [capacity credits](../serverless-signing/quick-start.md).
 
 :::note
-On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as look as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` or **not** valid on the `cayenne` network.
+On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as long as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` or **not** valid on the `cayenne` network.
 :::
 
 Below is a table detailing the expected behaviors of each:

--- a/docs/sdk/migrations/6.0.0.md
+++ b/docs/sdk/migrations/6.0.0.md
@@ -474,7 +474,7 @@ const authSig = await generateAuthSig({
 There has been some confusion on the parameters for `createCapacityDelegationAuthSig`, particularly `capacityTokenId`, `delegateeAddresses`, and `uses` when delegating [capacity credits](../serverless-signing/quick-start.md).
 
 :::note
-On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as long as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` or **not** valid on the `cayenne` network.
+On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as long as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` are **not** valid on the `cayenne` network.
 :::
 
 Below is a table detailing the expected behaviors of each:


### PR DESCRIPTION
Adds a note in the `Clarifications` section (at the bottom of the doc page) to tell users:

> On the Lit network, `cayenne`, payment for network usage is **not** required. However, when migrating to `v6`, if you use Capacity Credits or are delegating them, your code should still be functional as long as the Capacity Credits you're using were minted on the `cayenne` network. Capacity Credits minted on `manzano` or `habanero` or **not** valid on the `cayenne` network.