### PR TITLE
ref: node version update

### DIFF
--- a/docs/network/migration-guide.md
+++ b/docs/network/migration-guide.md
@@ -282,7 +282,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client-nodejs";
 </Tabs>
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for  **crypto** support.
 :::
 
 ## Connection to the Lit Network

--- a/docs/network/migration-guide.md
+++ b/docs/network/migration-guide.md
@@ -282,7 +282,9 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client-nodejs";
 </Tabs>
 
 :::note
-You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+You should use **at least Node v19.9.0**
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
 :::
 
 ## Connection to the Lit Network

--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -23,7 +23,10 @@ Ensure you have the following requirements in place:
 
 Install the `@lit-protocol/lit-node-client` package, which can be used in both browser and Node environments:
 
-You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+You should use **at least Node v19.9.0** for 
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
+
 
 ```jsx
 yarn add @lit-protocol/lit-node-client

--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -23,6 +23,8 @@ Ensure you have the following requirements in place:
 
 Install the `@lit-protocol/lit-node-client` package, which can be used in both browser and Node environments:
 
+You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+
 ```jsx
 yarn add @lit-protocol/lit-node-client
 ```
@@ -34,7 +36,17 @@ npm i @lit-protocol/lit-node-client
 ```
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+If you are using `NodeJS` you should install `@lit-protocol/lit-node-client-nodejs`
+:::
+
+Use the **Lit JS SDK V4**:
+
+```jsx
+import * as LitJsSdk from "@lit-protocol/lit-node-client";
+```
+
+:::note
+You should use **at least Node vv19.9.0** because of the need for  **crypto** support..
 :::
 
 You also need to install the following lit packages whose functions are used in the example below:

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -58,7 +58,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client-nodejs";
 </Tabs>
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for **crypto** support.
 :::
 
 ## Connection to the Lit Network

--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -41,7 +41,9 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client";
 ```
 
 :::note
-You should use **at least Node v19.9.0** because of the need for  **crypto** support..
+You should use **at least Node v19.9.0** for
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
 :::
 
 ### Client-Side Usage

--- a/docs/sdk/serverless-signing/quick-start.md
+++ b/docs/sdk/serverless-signing/quick-start.md
@@ -41,7 +41,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client";
 ```
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for  **crypto** support..
 :::
 
 ### Client-Side Usage

--- a/docs/sdk/wallets/quick-start.md
+++ b/docs/sdk/wallets/quick-start.md
@@ -40,7 +40,9 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client";
 ```
 
 :::note
-You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+You should use **at least Node v19.9.0**
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
 :::
 
 ### Client-Side Usage

--- a/docs/sdk/wallets/quick-start.md
+++ b/docs/sdk/wallets/quick-start.md
@@ -40,7 +40,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client";
 ```
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for  **crypto** support.
 :::
 
 ### Client-Side Usage

--- a/versioned_docs/version-2.0/sdk/explanation/installation.md
+++ b/versioned_docs/version-2.0/sdk/explanation/installation.md
@@ -65,7 +65,7 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client-nodejs";
 </Tabs>
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for  **crypto** support.
 :::
 
 ## Connection to the Lit Network

--- a/versioned_docs/version-2.0/sdk/explanation/installation.md
+++ b/versioned_docs/version-2.0/sdk/explanation/installation.md
@@ -65,7 +65,9 @@ import * as LitJsSdk from "@lit-protocol/lit-node-client-nodejs";
 </Tabs>
 
 :::note
-You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+You should use **at least Node v19.9.0**
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
 :::
 
 ## Connection to the Lit Network

--- a/versioned_docs/version-2.0/sdk/explanation/migration.md
+++ b/versioned_docs/version-2.0/sdk/explanation/migration.md
@@ -14,7 +14,9 @@ The **Lit JS SDK V2** has been entirely revamped from the earlier `lit-js-sdk` a
 ## Installing the V2 SDK
 
 :::note
-You should use **at least Node v19.9.0** because of the need for  **crypto** support.
+You should use **at least Node v19.9.0**
+- **crypto** support.
+- **webcrypto** library support if targeting `web`.
 :::
 
 Get started with **Lit JS SDK V2** by installing the package best suited for your environment.

--- a/versioned_docs/version-2.0/sdk/explanation/migration.md
+++ b/versioned_docs/version-2.0/sdk/explanation/migration.md
@@ -14,7 +14,7 @@ The **Lit JS SDK V2** has been entirely revamped from the earlier `lit-js-sdk` a
 ## Installing the V2 SDK
 
 :::note
-You should use **at least Node v16.16.0** because of the need for the **webcrypto** library.
+You should use **at least Node v19.9.0** because of the need for  **crypto** support.
 :::
 
 Get started with **Lit JS SDK V2** by installing the package best suited for your environment.


### PR DESCRIPTION
Updates our `NodeJS` version requirements to `19` from `16` for `crypto` native support if running in NodeJS