### PR TITLE
Typo fix in v6 migration guide

### DIFF
--- a/docs/sdk/migrations/6.0.0.md
+++ b/docs/sdk/migrations/6.0.0.md
@@ -289,7 +289,7 @@ In the `signSessionKey` parameters, we've added three extra optional arguments f
 
 For simplicity, we introduced `getPkpSessionSigs`, which uses `signSessionKey` under the hood.
 
-Here's the [AuthCalbackParams](https://github.com/LIT-Protocol/js-sdk/blob/635ec8da948103f3ce14271ccfc00393bc9e02a2/packages/types/src/lib/interfaces.ts#L45) interface for the `props`
+Here's the [AuthCallbackParams](https://github.com/LIT-Protocol/js-sdk/blob/635ec8da948103f3ce14271ccfc00393bc9e02a2/packages/types/src/lib/interfaces.ts#L45) interface for the `props`
 
 ```tsx
 // v5


### PR DESCRIPTION
Fixes a markdown typo for linking to an external page