### PR TITLE
fix: add 32 byte hashing to signAndCombineEcdsa example

### DIFF
--- a/docs/sdk/serverless-signing/combining-signatures.md
+++ b/docs/sdk/serverless-signing/combining-signatures.md
@@ -19,7 +19,9 @@ const code = `(async () => {
   // sign "hello world" and allow all the nodes to combine the signature and return it to the action.
   const utf8Encode = new TextEncoder();
   const toSign = utf8Encode.encode('Hello World');
-
+  ethers.utils.arrayify(
+    ethers.utils.keccak256(toSign)
+  );
   // Will use the authentication provided to the "executeJs" call from the sdk on the client.
   const signature = await Lit.Actions.signAndCombineEcdsa({
     toSign,


### PR DESCRIPTION
- Fixes `signAndCombineEcdsa` basic example with 32 byte hashing before signing.