### PR TITLE
Removed dup doc/Fixed source code URL

### DIFF
--- a/docs/sdk/wrapped-keys/custom-wrapped-keys.md
+++ b/docs/sdk/wrapped-keys/custom-wrapped-keys.md
@@ -19,22 +19,22 @@ Currently the Wrapped Keys SDK includes Lit Action to support the following:
 For Wrapped Keys derived from the `K256` algorithm (commonly known as `ecdsa`):
 
 - Generating `K256` (commonly known as `ecdsa`) private keys within a Lit Action
-  - Uses the [generateEncryptedEthereumPrivateKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/ethereum/src/generateEncryptedEthereumPrivateKey.js) Lit Action
+  - Uses the [generateEncryptedEthereumPrivateKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/generateEncryptedEthereumPrivateKey.js) Lit Action
 - Signing arbitrary messages using Ethers.js' [signMessage](https://docs.ethers.org/v5/api/signer/#Signer-signMessage)
-  - Uses the [signMessageWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js) Lit Action
+  - Uses the [signMessageWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js) Lit Action
 - Signing Ethers.js transaction objects using [signTransaction](https://docs.ethers.org/v5/api/signer/#Signer-signTransaction)
-  - Uses the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js) Lit Action
+  - Uses the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js) Lit Action
 
 ### Wrapped Keys Derived `ed25519` Algorithm
 
 For Wrapped Keys derived from the `ed25519` algorithm (used for Solana private key):
 
 - Generating `ed25519` private keys within a Lit Action using the [@solana/web3.js](https://github.com/solana-labs/solana-web3.js) SDK
-  - Uses the [generateEncryptedSolanaPrivateKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/solana/src/generateEncryptedSolanaPrivateKey.js) Lit Action
+  - Uses the [generateEncryptedSolanaPrivateKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/generateEncryptedSolanaPrivateKey.js) Lit Action
 - Signing arbitrary messages using the `@solana/web3.js` SDK
-  - Uses the [signMessageWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js) Lit Action
+  - Uses the [signMessageWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js) Lit Action
 - Signing Solana transaction objects using the `@solana/web3.js` SDK
-  - uses the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js) Lit Action
+  - uses the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js) Lit Action
 
 ## Implementing a Custom Lit Action
 
@@ -68,7 +68,7 @@ If you manually encrypt your private key with custom Access Control Conditions, 
 
 The [Ethers.js v5](https://docs.ethers.org/v5/) SDK is already made available within a Lit Action. For any other SDK, you'll need to bundle the code with your Lit Action. Lit Actions execute within a [Deno](https://deno.com/) environment, so any APIs that aren't supported by Deno will need to be accounted for via polyfills and/or shims.
 
-As a reference implementation, the Wrapped Keys SDK uses [esbuild](https://esbuild.github.io/) to bundle the `@solana/web3.js` SDK with the Lit Action code, and provide the required shim. [This](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/esbuild.config.js) is the `esbuild.config.js` used and [this](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/buffer.shim.js) is the shim used to include [buffer](https://www.npmjs.com/package/buffer) within the bundled Lit Action code.
+As a reference implementation, the Wrapped Keys SDK uses [esbuild](https://esbuild.github.io/) to bundle the `@solana/web3.js` SDK with the Lit Action code, and provide the required shim. [This](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/esbuild.config.js) is the `esbuild.config.js` used and [this](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/buffer.shim.js) is the shim used to include [buffer](https://www.npmjs.com/package/buffer) within the bundled Lit Action code.
 
 Then, as you can see in the [Solana Wrapped Keys Lit Actions](#wrapped-keys-derived-ed25519-algorithm), various `@solana/web3.js` exports are `import`ed into the Lit Action code as usual.
 
@@ -220,9 +220,9 @@ After implementing your custom Lit Action, you'll want to make use of Lit SDK's 
 
 As a reference implementation, you can take a look at the following methods used by the Wrapped Keys SDK to call the [Provided Wrapped Keys Lit Actions](#provided-wrapped-keys-lit-actions):
 
-- [generateKeyWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/lit-actions-client/generate-key.ts)
-- [signMessageWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/lit-actions-client/sign-message.ts)
-- [signTransactionWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/lit-actions-client/sign-transaction.ts)
+- [generateKeyWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/lit-actions-client/generate-key.ts)
+- [signMessageWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/lit-actions-client/sign-message.ts)
+- [signTransactionWithLitAction](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/lit-actions-client/sign-transaction.ts)
 
 To call `executeJs`, you'll need to pass the following arguments:
 

--- a/docs/sdk/wrapped-keys/exporting-wrapped-key.md
+++ b/docs/sdk/wrapped-keys/exporting-wrapped-key.md
@@ -19,7 +19,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `exportPrivateKey`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/export-private-key.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/export-private-key.ts)
 
 ```ts
 /** Exports a previously persisted private key from the wrapped keys service for direct use by the caller, along with the keys metadata

--- a/docs/sdk/wrapped-keys/generating-wrapped-key.md
+++ b/docs/sdk/wrapped-keys/generating-wrapped-key.md
@@ -22,7 +22,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `generatePrivateKey`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/generate-private-key.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/generate-private-key.ts)
 
 ```ts
 /**

--- a/docs/sdk/wrapped-keys/generating-wrapped-key.md
+++ b/docs/sdk/wrapped-keys/generating-wrapped-key.md
@@ -77,7 +77,7 @@ This is an instance of the [LitNodeClient](https://v6-api-doc-lit-js-sdk.vercel.
 #### `network`
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-This parameter dictates what elliptic curve is used to generate the private key. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/types.ts#L12) which currently consists of:
+This parameter dictates what elliptic curve is used to generate the private key. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/types.ts#L12) which currently consists of:
 
   - `evm` This will generate a private key using the ECDSA curve.
   - `solana` This will generate a private key using the Ed25519 curve.
@@ -85,7 +85,7 @@ This parameter dictates what elliptic curve is used to generate the private key.
 ### Return Value
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-`generatePrivateKey` will return a [GeneratePrivateKeyResult](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/types.ts#L82-L90) object after it successfully generates and encrypts the private key and stores the encryption metadata.
+`generatePrivateKey` will return a [GeneratePrivateKeyResult](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/types.ts#L82-L90) object after it successfully generates and encrypts the private key and stores the encryption metadata.
 
 ```ts
 /** @typedef GeneratePrivateKeyResult

--- a/docs/sdk/wrapped-keys/getting-wrapped-key-metadata.md
+++ b/docs/sdk/wrapped-keys/getting-wrapped-key-metadata.md
@@ -20,7 +20,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `getEncryptedKeyMetadata`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/get-encrypted-key-metadata.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/get-encrypted-key-metadata.ts)
 
 ```ts
 /** Get a previously encrypted and persisted private key and its metadata.

--- a/docs/sdk/wrapped-keys/importing-key.md
+++ b/docs/sdk/wrapped-keys/importing-key.md
@@ -22,7 +22,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `importPrivateKey`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/import-private-key.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/import-private-key.ts)
 
 ```ts
 /**

--- a/docs/sdk/wrapped-keys/overview.md
+++ b/docs/sdk/wrapped-keys/overview.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 Wrapped Keys are private keys that are either imported into the Lit network, or generated within the trusted execution environment (TEE) of a Lit node via a Lit Action.
 
-Wrapped Keys are private keys that are either imported into the Lit network, or generated within the trusted execution environment (TEE) of a Lit node via a Lit Action. The private keys are first encrypted using Lit network's BLS key, then the resulting encryption metadata (`ciphertext` and `dataToEncryptHash`) is stored by Lit, in a private instance of DynamoDB, for retrieval when you request a Lit node to sign with your Wrapped Key.
+The private keys are first encrypted using Lit network's BLS key, then the resulting encryption metadata (`ciphertext` and `dataToEncryptHash`) is stored by Lit, in a private instance of DynamoDB, for retrieval when you request a Lit node to sign with your Wrapped Key.
 
 Using the Wrapped Keys SDK, you can request a Lit node to sign arbitrary messages and transactions, optionally sending signed transaction to a network. The Lit node will combine decryption shares of your Wrapped Key from other Lit nodes within it's TEE. This results in the complete unencrypted key used for signing only existing temporarily within the secure execution context of a Lit node's TEE.
 

--- a/docs/sdk/wrapped-keys/sign-message.md
+++ b/docs/sdk/wrapped-keys/sign-message.md
@@ -19,7 +19,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `signMessageWithEncryptedKey`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/sign-message-with-encrypted-key.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/sign-message-with-encrypted-key.ts)
 
 ```ts
 /**
@@ -71,12 +71,12 @@ This is an instance of the [LitNodeClient](https://v6-api-doc-lit-js-sdk.vercel.
 
 <!-- TODO Update URLs once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
 
-This parameter dictates what message signing Lit Action is used to sign `messageToSign`. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/types.ts#L9-L12) which currently consists of:
+This parameter dictates what message signing Lit Action is used to sign `messageToSign`. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/types.ts#L9-L12) which currently consists of:
 
-  - `evm` This will use the [signMessageWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js) Lit Action.
+  - `evm` This will use the [signMessageWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js) Lit Action.
     - Use this network if your Wrapped Key is a private key derived from the ECDSA curve. 
     - Uses Ethers.js' [signMessage](https://docs.ethers.org/v5/api/signer/#Signer-signMessage) function to sign `messageToSign`.
-  - `solana` This will use the [signMessageWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js) Lit Action.
+  - `solana` This will use the [signMessageWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js) Lit Action.
     - Use this network if your Wrapped Key is a private key derived from the Ed25519 curve.
     - Uses the [@solana/web3.js](https://github.com/solana-labs/solana-web3.js) package to create a signer using the decrypted Wrapped Key, and the [tweetnacl](https://github.com/dchest/tweetnacl-js) package to sign `messageToSign`.
 

--- a/docs/sdk/wrapped-keys/sign-transaction.md
+++ b/docs/sdk/wrapped-keys/sign-transaction.md
@@ -19,7 +19,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `signTransactionWithEncryptedKey`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/sign-transaction-with-encrypted-key.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/sign-transaction-with-encrypted-key.ts)
 
 <Tabs
 defaultValue="evm"
@@ -153,12 +153,12 @@ This is an instance of the [LitNodeClient](https://v6-api-doc-lit-js-sdk.vercel.
 
 <!-- TODO Update URLs once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
 
-This parameter dictates what transaction signing Lit Action is used to sign `unsignedTransaction`. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/types.ts#L9-L12) which currently consists of:
+This parameter dictates what transaction signing Lit Action is used to sign `unsignedTransaction`. It must be one of the supported Wrapped Keys [Networks](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/types.ts#L9-L12) which currently consists of:
 
-  - `evm` This will use the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js) Lit Action.
+  - `evm` This will use the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js) Lit Action.
     - Use this network if your Wrapped Key is a private key derived from the ECDSA curve.
     - Uses Ethers.js' [signTransaction](https://docs.ethers.org/v5/api/signer/#Signer-signTransaction) function to sign `unsignedTransaction`.
-  - `solana` This will use the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js) Lit Action.
+  - `solana` This will use the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js) Lit Action.
     - Use this network if your Wrapped Key is a private key derived from the Ed25519 curve.
     - Uses the [@solana/web3.js](https://github.com/solana-labs/solana-web3.js) package to create a signer using the decrypted Wrapped Key, and a [Transaction](https://solana-labs.github.io/solana-web3.js/classes/Transaction.html) instance to sign the serialized unsigned transaction.
 

--- a/docs/sdk/wrapped-keys/storing-wrapped-key-metadata.md
+++ b/docs/sdk/wrapped-keys/storing-wrapped-key-metadata.md
@@ -23,7 +23,7 @@ Before continuing with this guide, you should have an understanding of:
 ## `storeEncryptedKeyMetadata`'s Interface
 
 <!-- TODO Update URL once Wrapped Keys PR is merged: https://github.com/LIT-Protocol/js-sdk/pull/513 -->
-[Source code](https://github.com/LIT-Protocol/js-sdk/blob/ac8f17372a2c0a204286515e35b6abeb26e1effc/packages/wrapped-keys/src/lib/api/store-encrypted-key-metadata.ts)
+[Source code](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/api/store-encrypted-key-metadata.ts)
 
 ```ts
 /** Get a previously encrypted and persisted private key and its metadata.


### PR DESCRIPTION
Updated the bugs noticed by Daryl.

More specifically:
The source code for the 'wrapped keys - generate private keys' was to a specific commit hash, not the master branch.
There was duplicate text in the wrapped keys overview.
