### PR TITLE
feat: Add warning for Habanero Wrapped Keys

### DIFF
--- a/docs/sdk/wrapped-keys/generating-wrapped-key.md
+++ b/docs/sdk/wrapped-keys/generating-wrapped-key.md
@@ -3,6 +3,10 @@ import TabItem from '@theme/TabItem';
 
 # Generating a New Key
 
+:::warning
+Wrapped Key are under active development please do **not** use it for production i.e. do not use it on Habanero. It will be available for production very soon.
+:::
+
 This guide covers the `generatePrivateKey` function from the Wrapped Keys SDK. For an overview of what a Wrapped Key is and what can be done with it, please go [here](./overview.md).
 
 Using the `generatePrivateKey` function, you can request a Lit node to generate a new private key within it's trusted execution environment (TEE). Once generated, the private key will be encrypted using Lit network's BLS key, and the resulting encryption metadata (`ciphertext` and `dataToEncryptHash`) will be returned and stored by Lit on your behalf in a private DynamoDB instance.


### PR DESCRIPTION
# Description

Add warning for not using Wrapped Keys for Production (Habanero).

## Type of change

- [X] Warning

# Checklist:

General
- [X] I have performed a self-review of my code
- [X] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [X] I have checked the additions are concise
- [X] Language is consistent with existing documentation
- [X] My changes generate no new warnings
