### PR TITLE
Changed the IPFS ID Access Control Parameter Example

### DIFF
--- a/docs/sdk/serverless-signing/combining-decryption-shares.md
+++ b/docs/sdk/serverless-signing/combining-decryption-shares.md
@@ -56,12 +56,12 @@ When defining your Access Control Conditions rules you may wish to use `currentA
 {
   contractAddress: '',
   standardContractType: '',
-  chain,
-  method: 'eth_getBalance',
-  parameters: [':currentActionIpfsId', 'latest'],
+  chain: 'ethereum',
+  method: '',
+  parameters: [':currentActionIpfsId'],
   returnValueTest: {
     comparator: '=',
-    value: '<your ipfs id>',
+    value: 'Lit Action IPFS CID',
   },
 }
 ```

--- a/docs/sdk/serverless-signing/combining-decryption-shares.md
+++ b/docs/sdk/serverless-signing/combining-decryption-shares.md
@@ -61,7 +61,7 @@ When defining your Access Control Conditions rules you may wish to use `currentA
   parameters: [':currentActionIpfsId'],
   returnValueTest: {
     comparator: '=',
-    value: 'Lit Action IPFS CID',
+    value: '<YOUR_LIT_ACTION_IPFS_CID>',
   },
 }
 ```


### PR DESCRIPTION
Changed the `Using IPFS ID as an Access Control Parameter` example to be accurate.
