### PR TITLE
Init Mainnets and Testnets pages

### DIFF
--- a/docs/learn/overview/how-it-works/lit-networks/mainnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/mainnets.md
@@ -12,7 +12,7 @@ While mainnets may be deprecated in the future, assets will be transferable to n
 
 | Name  | Lit Blockchain                                                   | Description                                                                                                                                 | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
 |-------|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
-| Datil | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) | Decentralized mainnet designed for production deployment. Guaranteed real world asset transferability to new mainnets. Payment is enforced. | `^6.4.0`                | `datil`                    | ✅                |
+| Datil | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) | Decentralized mainnet designed for production deployment. Guaranteed real world asset transferability to new mainnets. Payment is enforced. | `6.x.x`                | `datil`                    | ✅                |
 
 ## The Datil Network
 
@@ -22,7 +22,7 @@ If your application is currently deployed on Lit networks: Cayenne, Manzano, and
 
 ### Lit SDK Version Compatibility
 
-The minimum version of the Lit SDK that supports `datil` is `6.4.0`. You can install the latest SDK version from NPM, which includes this support by default:
+The minimum version of the Lit SDK that supports `datil` is the latest `6.x.x` release. You can install the latest SDK version from NPM, which includes this support by default:
 
 <Tabs
 defaultValue="npm"
@@ -59,9 +59,10 @@ To connect to Datil, please follow the [Connecting to a Lit Network](../../../..
 
 ```ts
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { LitNetwork } from "@lit-protocol/constants";
 
 const litNodeClient = new LitNodeClient({
-  litNetwork: 'datil',
+  litNetwork: LitNetwork.Datil,
 });
 await litNodeClient.connect();
 ```

--- a/docs/learn/overview/how-it-works/lit-networks/mainnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/mainnets.md
@@ -4,20 +4,17 @@ import TabItem from '@theme/TabItem';
 
 # Mainnets
 
-Lit mainnets are designed for late-stage development and production deployment. If you are storing assets with real world value, it should be done on the mainnets and not the testnets.
-
-While mainnets may be deprecated in the future, assets will be transferable to new networks.
-
+Lit mainnets are designed for late-stage development and production deployment. If you are storing assets with real world value, it should be done on a Lit mainnet network, which are linked below. Real world assets and tokens should **NEVER** be managed on any Lit testnet.
 
 ## Overview of Lit Mainnets
 
-| Name  | Lit Blockchain                                                   | Description                                                                                                                                 | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
-|-------|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
-| Datil | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) | Decentralized mainnet designed for production deployment. Guaranteed real world asset transferability to new mainnets. Payment is enforced. | `6.x.x`                | `datil`                    | ✅                |
+| Name  | Lit Blockchain                                                   | Description                                                                                                            | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
+| ----- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------------- | ---------------- |
+| Datil | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) | Decentralized mainnet designed for production deployment. Guaranteed persistence of key material. Payment is enforced. | `6.x.x`                 | `datil`                    | ✅                |
 
 ## The Datil Network
 
-The Lit network, **Datil**, utilizes the Lit blockchain: **Chronicle Yellowstone**. It's a decentralized mainnet designed for production deployment, and is superseding the Habanero mainnet. Like Habanero, usage of the network **requires** [payment for usage of the network](../../../paying-for-lit/overview.md).
+The Lit network, **Datil**, utilizes the Lit blockchain: **Chronicle Yellowstone**. It's a decentralized mainnet designed for production deployment, and is superseding [the Habanero mainnet](https://spark.litprotocol.com/introducing-decentralized-key-management-with-lit-v0). Like Habanero, usage of the network **requires** [payment for usage of the network](../../../paying-for-lit/overview.md).
 
 If your application is currently deployed on Lit networks: Cayenne, Manzano, and/or Habanero, please refer to [this migration guide](./migrating-to-datil) to learn how to migrate to the new Datil networks.
 

--- a/docs/learn/overview/how-it-works/lit-networks/mainnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/mainnets.md
@@ -1,1 +1,67 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Mainnets
+
+Lit mainnets are designed for late-stage development and production deployment. If you are storing assets with real world value, it should be done on the mainnets and not the testnets.
+
+While mainnets may be deprecated in the future, assets will be transferable to new networks.
+
+
+## Overview of Lit Mainnets
+
+| Name  | Lit Blockchain                                                   | Description                                                                                                                                 | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
+|-------|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
+| Datil | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) | Decentralized mainnet designed for production deployment. Guaranteed real world asset transferability to new mainnets. Payment is enforced. | `^6.4.0`                | `datil`                    | ✅                |
+
+## The Datil Network
+
+The Lit network, **Datil**, utilizes the Lit blockchain: **Chronicle Yellowstone**. It's a decentralized mainnet designed for production deployment, and is superseding the Habanero mainnet. Like Habanero, usage of the network **requires** [payment for usage of the network](../../../paying-for-lit/overview.md).
+
+If your application is currently deployed on Lit networks: Cayenne, Manzano, and/or Habanero, please refer to [this migration guide](./migrating-to-datil) to learn how to migrate to the new Datil networks.
+
+### Lit SDK Version Compatibility
+
+The minimum version of the Lit SDK that supports `datil` is `6.4.0`. You can install the latest SDK version from NPM, which includes this support by default:
+
+<Tabs
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
+```bash
+npm install @lit-protocol/lit-node-client
+```
+
+</TabItem>
+
+<TabItem value="yarn">
+
+```bash
+yarn add @lit-protocol/lit-node-client
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+
+If you are coming from version `5` of the Lit SDK, there are no breaking changes to the API in version `6`. Therefore, code written for Habanero should work seamlessly on Datil. If you encounter any issues after migrating to Datil, please reach out to us on [Telegram](https://t.me/+aa73FAF9Vp82ZjJh) for support.
+
+:::
+
+### Connecting to Datil
+
+To connect to Datil, please follow the [Connecting to a Lit Network](../../../../build/getting-started/connecting-to-lit) guide, using `datil` as the `litNetwork` property when instantiating an instance of the `LitNodeClient`:
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+
+const litNodeClient = new LitNodeClient({
+  litNetwork: 'datil',
+});
+await litNodeClient.connect();
+```

--- a/docs/learn/overview/how-it-works/lit-networks/mainnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/mainnets.md
@@ -1,3 +1,4 @@
+import FeedbackComponent from "@site/src/pages/feedback.md";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -66,3 +67,5 @@ const litNodeClient = new LitNodeClient({
 });
 await litNodeClient.connect();
 ```
+
+<FeedbackComponent/>

--- a/docs/learn/overview/how-it-works/lit-networks/testnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/testnets.md
@@ -1,1 +1,119 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Testnets
+
+Test networks are designed for early-stage application development. Storing assets with real-world value on these networks is **highly discouraged**, and minted PKPs (Programmable Key Pairs) may be deleted.
+
+:::warning
+
+All test networks may be **deprecated** in the future.
+
+Use one of the [mainnets](./mainnets) for longer term persistence, and for handling assets with real-world value.
+
+:::
+
+## Overview of Lit Testnets
+
+| Name       | Lit Blockchain                                                      | Description                                                                                                                                                                   | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
+|------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
+| Datil-test | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for pre-production development. No persistency guarantees. Payment is enforced.                                                                  | `^6.4.0`                | `datil-test`               | ✅                |
+| Datil-dev  | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for early-stage development. Keys are not persistent and may be deleted. This network does not enforce payment and can be used for free testing. | `^6.4.0`                | `datil-dev`                | ❌                |
+
+:::info
+
+If you are coming from version `5` of the Lit SDK, there are no breaking changes to the API in version `6`. Therefore, code written for Habanero should work seamlessly on Datil. If you encounter any issues after migrating to Datil, please reach out to us on [Telegram](https://t.me/+aa73FAF9Vp82ZjJh) for support.
+
+:::
+
+## The Datil-test Network
+
+The Lit network **Datil-test** utilizes the Lit blockchain: **Chronicle Yellowstone**. It's a centralized testnet designed for pre-production development and supersedes the Manzano testnet. Like Manzano, usage of the network **requires** [payment for usage of the network](../../../paying-for-lit/overview.md).
+
+If your application is currently deployed on Lit networks: Cayenne, Manzano, and/or Habanero, please refer to [this migration guide](./migrating-to-datil) to learn how to migrate to the new Datil networks.
+
+### Lit SDK Version Compatibility
+
+The minimum version of the Lit SDK that supports `datil-test` is `6.4.0`. You can install the latest SDK version from NPM, which includes this support by default:
+
+<Tabs
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
+```bash
+npm install @lit-protocol/lit-node-client
+```
+
+</TabItem>
+
+<TabItem value="yarn">
+
+```bash
+yarn add @lit-protocol/lit-node-client
+```
+
+</TabItem>
+</Tabs>
+
+### Connecting to Datil-test
+
+To connect to Datil-test, please follow the [Connecting to a Lit Network](../../../../build/getting-started/connecting-to-lit) guide, using `datil-test` as the `litNetwork` property when instantiating an instance of the `LitNodeClient`:
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+
+const litNodeClient = new LitNodeClient({
+  litNetwork: 'datil',
+});
+await litNodeClient.connect();
+```
+
+## Datil-dev Network
+
+The Lit network **Datil-dev** utilizes the Lit blockchain called **Chronicle Yellowstone**. It's a centralized testnet designed for early-stage development and supersedes the Cayenne testnet. Unlike Datil-test, usage of the network does **not** require payment for usage of the network.
+
+If your application is currently deployed on Lit networks: Cayenne, Manzano, and/or Habanero, please refer to [this migration guide](./migrating-to-datil) to learn how to migrate to the new Datil networks.
+
+### Lit SDK Version Compatibility
+
+The minimum version of the Lit SDK that supports `datil-dev` is `6.4.0`. You can install the latest SDK version from NPM:
+
+<Tabs
+defaultValue="npm"
+values={[
+{label: 'npm', value: 'npm'},
+{label: 'yarn', value: 'yarn'},
+]}>
+<TabItem value="npm">
+
+```bash
+npm install @lit-protocol/lit-node-client
+```
+
+</TabItem>
+
+<TabItem value="yarn">
+
+```bash
+yarn add @lit-protocol/lit-node-client
+```
+
+</TabItem>
+</Tabs>
+
+### Connecting to Datil-dev
+
+To connect to Datil-dev, please follow the [Connecting to a Lit Network](../../../../build/getting-started/connecting-to-lit) guide, using `datil-dev` as the `litNetwork` property when instantiating an instance of the `LitNodeClient`:
+
+```ts
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+
+const litNodeClient = new LitNodeClient({
+  litNetwork: 'datil',
+});
+await litNodeClient.connect();
+```

--- a/docs/learn/overview/how-it-works/lit-networks/testnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/testnets.md
@@ -17,8 +17,8 @@ Use one of the [mainnets](./mainnets) for longer term persistence, and for handl
 
 | Name       | Lit Blockchain                                                      | Description                                                                                                                                                                   | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
 |------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
-| Datil-test | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for pre-production development. No persistency guarantees. Payment is enforced.                                                                  | `^6.4.0`                | `datil-test`               | ✅                |
-| Datil-dev  | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for early-stage development. Keys are not persistent and may be deleted. This network does not enforce payment and can be used for free testing. | `^6.4.0`                | `datil-dev`                | ❌                |
+| Datil-test | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for pre-production development. No persistency guarantees. Payment is enforced.                                                                  | `6.x.x`                | `datil-test`               | ✅                |
+| Datil-dev  | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for early-stage development. Keys are not persistent and may be deleted. This network does not enforce payment and can be used for free testing. | `6.x.x`                | `datil-dev`                | ❌                |
 
 :::info
 
@@ -34,7 +34,7 @@ If your application is currently deployed on Lit networks: Cayenne, Manzano, and
 
 ### Lit SDK Version Compatibility
 
-The minimum version of the Lit SDK that supports `datil-test` is `6.4.0`. You can install the latest SDK version from NPM, which includes this support by default:
+The minimum version of the Lit SDK that supports `datil-test` is the latest `6.x.x` release. You can install the latest SDK version from NPM, which includes this support by default:
 
 <Tabs
 defaultValue="npm"
@@ -65,9 +65,10 @@ To connect to Datil-test, please follow the [Connecting to a Lit Network](../../
 
 ```ts
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { LitNetwork } from "@lit-protocol/constants";
 
 const litNodeClient = new LitNodeClient({
-  litNetwork: 'datil',
+  litNetwork: LitNetwork.DatilTest,
 });
 await litNodeClient.connect();
 ```
@@ -80,7 +81,7 @@ If your application is currently deployed on Lit networks: Cayenne, Manzano, and
 
 ### Lit SDK Version Compatibility
 
-The minimum version of the Lit SDK that supports `datil-dev` is `6.4.0`. You can install the latest SDK version from NPM:
+The minimum version of the Lit SDK that supports `datil-dev` is the latest `6.x.x` release. You can install the latest SDK version from NPM:
 
 <Tabs
 defaultValue="npm"
@@ -111,9 +112,10 @@ To connect to Datil-dev, please follow the [Connecting to a Lit Network](../../.
 
 ```ts
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { LitNetwork } from "@lit-protocol/constants";
 
 const litNodeClient = new LitNodeClient({
-  litNetwork: 'datil',
+  litNetwork: LitNetwork.DatilDev,
 });
 await litNodeClient.connect();
 ```

--- a/docs/learn/overview/how-it-works/lit-networks/testnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/testnets.md
@@ -1,6 +1,6 @@
+import FeedbackComponent from "@site/src/pages/feedback.md";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
 # Testnets
 
 Test networks are designed for early-stage application development. Storing assets with real-world value on these networks is **highly discouraged**, and minted PKPs (Programmable Key Pairs) may be deleted.
@@ -119,3 +119,5 @@ const litNodeClient = new LitNodeClient({
 });
 await litNodeClient.connect();
 ```
+
+<FeedbackComponent/>

--- a/docs/learn/overview/how-it-works/lit-networks/testnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/testnets.md
@@ -10,16 +10,16 @@ Test networks are designed for early-stage application development. Storing asse
 
 All test networks may be **deprecated** in the future.
 
-Use one of the [mainnets](./mainnets) for longer term persistence, and for handling assets with real-world value.
+Use one of the [mainnets](./mainnets) for guaranteed persistence of key material, and for handling assets with real-world value.
 
 :::
 
 ## Overview of Lit Testnets
 
 | Name       | Lit Blockchain                                                      | Description                                                                                                                                                                   | Minimum Lit SDK Version | Lit SDK Network Identifier | Requires Payment |
-|------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------------------------|------------------|
-| Datil-test | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for pre-production development. No persistency guarantees. Payment is enforced.                                                                  | `6.x.x`                | `datil-test`               | ✅                |
-| Datil-dev  | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for early-stage development. Keys are not persistent and may be deleted. This network does not enforce payment and can be used for free testing. | `6.x.x`                | `datil-dev`                | ❌                |
+| ---------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------------- | ---------------- |
+| Datil-test | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for pre-production development. No persistency guarantees. Payment is enforced.                                                                  | `6.x.x`                 | `datil-test`               | ✅                |
+| Datil-dev  | [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone.md) | Centralized testnet designed for early-stage development. Keys are not persistent and may be deleted. This network does not enforce payment and can be used for free testing. | `6.x.x`                 | `datil-dev`                | ❌                |
 
 :::info
 

--- a/docs/learn/overview/how-it-works/lit-networks/testnets.md
+++ b/docs/learn/overview/how-it-works/lit-networks/testnets.md
@@ -1,6 +1,7 @@
 import FeedbackComponent from "@site/src/pages/feedback.md";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
 # Testnets
 
 Test networks are designed for early-stage application development. Storing assets with real-world value on these networks is **highly discouraged**, and minted PKPs (Programmable Key Pairs) may be deleted.


### PR DESCRIPTION
Slightly refactors the Lit network pages:

- [Mainnets](https://developer.litprotocol.com/connecting-to-a-lit-network/mainnets)
- [Testnets](https://developer.litprotocol.com/connecting-to-a-lit-network/testnets)