### PR TITLE
updates to tools page

### DIFF
--- a/docs/tools/event-listener.md
+++ b/docs/tools/event-listener.md
@@ -2,7 +2,7 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 
 # Event Listener
 
-:::note
+:::warning
 
 The Lit Event Listener tool is currently **incompatible** with the latest version of the Lit SDK and must be updated before it can be used by developers building on any of the Lit ['Datil' networks](../connecting-to-a-lit-network/connecting.md). These updates are planned and the community will be notified as soon as they've been completed. 
 

--- a/docs/tools/event-listener.md
+++ b/docs/tools/event-listener.md
@@ -2,6 +2,16 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 
 # Event Listener
 
+:::note
+
+The Lit Event Listener tool is currently **incompatible** with the latest version of the Lit SDK and must be updated before it can be used by developers building on any of the Lit ['Datil' networks](../connecting-to-a-lit-network/connecting.md). These updates are planned and the community will be notified as soon as they've been completed. 
+
+If you're new to Lit Actions and are looking for a place to start, please consult the [quick start](../sdk/serverless-signing/quick-start.md) guide.
+
+If you have a support request or would like to stay up to date with the latest updates, please join Lit's [Ecosystem Builders channel](https://t.me/+aa73FAF9Vp82ZjJh) on Telegram.
+
+:::
+
  <iframe width="640" 
          height="480" 
          src="https://www.youtube.com/embed/gcT8Bp5oepo" 

--- a/docs/tools/getlit-cli.md
+++ b/docs/tools/getlit-cli.md
@@ -6,7 +6,7 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 
 # GetLit CLI
 
-:::note
+:::warning
 
 The GetLit CLI tool is currently **incompatible** with the latest version of the Lit SDK and must be updated before it can be used by developers building on any of the Lit ['Datil' networks](../connecting-to-a-lit-network/connecting.md). These updates are planned and the community will be notified as soon as they've been completed. 
 

--- a/docs/tools/getlit-cli.md
+++ b/docs/tools/getlit-cli.md
@@ -6,6 +6,16 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 
 # GetLit CLI
 
+:::note
+
+The GetLit CLI tool is currently **incompatible** with the latest version of the Lit SDK and must be updated before it can be used by developers building on any of the Lit ['Datil' networks](../connecting-to-a-lit-network/connecting.md). These updates are planned and the community will be notified as soon as they've been completed. 
+
+If you're new to Lit Actions and are looking for a place to start, please consult the [quick start](../sdk/serverless-signing/quick-start.md) guide.
+
+If you have a support request or would like to stay up to date with the latest updates, please join Lit's [Ecosystem Builders channel](https://t.me/+aa73FAF9Vp82ZjJh) on Telegram.
+
+:::
+
 ![](https://raw.githubusercontent.com/LIT-Protocol/getlit/main/banner.png)
 
 The GetLit CLI is a command-line tool designed to help developers manage their Lit Actions projects. The CLI provides a set of commands to create, build, test, and configure Lit Actions.


### PR DESCRIPTION
I added callouts to the tools pages (getLit CLI and event listener) to let devs know that they are currently incompatible with the latest SDK
