### PR TITLE
SessionSigs No Cache Warning

### DIFF
--- a/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a Lit Action
 
 :::warning
-Please do not cache session signatures, and instead generate them on-demand.
+Please do not cache Session Signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getLitActionSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
@@ -8,6 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # Using a Lit Action
 
+:::warning
+Instead of manually caching Session Signatures, please generate them on-demand.
+:::
+
 This guide covers the `getLitActionSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).
 
 Using the `getLitActionSessionSigs` function, you can specify the capabilities of your current session on the Lit network. 

--- a/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-lit-action-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a Lit Action
 
 :::warning
-Instead of manually caching Session Signatures, please generate them on-demand.
+Please do not cache session signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getLitActionSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a PKP
 
 :::warning
-Please do not cache session signatures, and instead generate them on-demand.
+Please do not cache Session Signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getPkpSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
@@ -8,6 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # Using a PKP
 
+:::warning
+Instead of manually caching Session Signatures, please generate them on-demand.
+:::
+
 This guide covers the `getPkpSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).
 
 Using the `getPkpSessionSigs` function, you can specify the capabilities of your current session on the Lit network. 

--- a/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-pkp-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a PKP
 
 :::warning
-Instead of manually caching Session Signatures, please generate them on-demand.
+Please do not cache session signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getPkpSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using an Auth Sig
 
 :::warning
-Instead of manually caching Session Signatures, please generate them on-demand.
+Please do not cache session signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using an Auth Sig
 
 :::warning
-Please do not cache session signatures, and instead generate them on-demand.
+Please do not cache Session Signatures, and instead generate them on-demand.
 :::
 
 This guide covers the `getSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).

--- a/docs/sdk/authentication/session-sigs/get-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/get-session-sigs.md
@@ -8,6 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # Using an Auth Sig
 
+:::warning
+Instead of manually caching Session Signatures, please generate them on-demand.
+:::
+
 This guide covers the `getSessionSigs` function from the Lit SDK. For an overview of what Session Signatures are and how they are to be used, please go [here](./intro).
 
 Using the `getSessionSigs` function, you can specify the capabilities of your current session on the Lit network.

--- a/docs/sdk/authentication/session-sigs/intro.md
+++ b/docs/sdk/authentication/session-sigs/intro.md
@@ -7,7 +7,7 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 # Session Signatures
 
 :::warning
-Instead of manually caching Session Signatures, please generate them on-demand.
+Please do not cache session signatures, and instead generate them on-demand.
 :::
 
 Session Signatures are used to authenticate with the Lit nodes and create a secure connection to the Lit network. 

--- a/docs/sdk/authentication/session-sigs/intro.md
+++ b/docs/sdk/authentication/session-sigs/intro.md
@@ -7,7 +7,7 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 # Session Signatures
 
 :::warning
-Please do not cache session signatures, and instead generate them on-demand.
+Please do not cache Session Signatures, and instead generate them on-demand.
 :::
 
 Session Signatures are used to authenticate with the Lit nodes and create a secure connection to the Lit network. 

--- a/docs/sdk/authentication/session-sigs/intro.md
+++ b/docs/sdk/authentication/session-sigs/intro.md
@@ -6,6 +6,10 @@ import FeedbackComponent from "@site/src/pages/feedback.md";
 
 # Session Signatures
 
+:::warning
+Instead of manually caching Session Signatures, please generate them on-demand.
+:::
+
 Session Signatures are used to authenticate with the Lit nodes and create a secure connection to the Lit network. 
 
 Generating a Session Signature is required whenever you want to request a specific [Lit Ability](https://v7-api-doc-lit-js-sdk.vercel.app/variables/constants_src.LIT_ABILITY.html) (e.g. signing a transaction) for a particular Lit Resource (e.g. a PKP).

--- a/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
@@ -1,4 +1,16 @@
+---
+sidebar_position: 2
+---
+
+import FeedbackComponent from "@site/src/pages/feedback.md";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Using a Sign-in With Solana Message
+
+:::warning
+Instead of manually caching Session Signatures, please generate them on-demand.
+:::
 
 This guide builds on the [Sign-in With Solana Authentication](../authenticating-siws) guide to show how to use Lit Actions to generate PKP Session Signatures for an authorized Solana public key.
 

--- a/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a Sign-in With Solana Message
 
 :::warning
-Please do not cache session signatures, and instead generate them on-demand.
+Please do not cache Session Signatures, and instead generate them on-demand.
 :::
 
 This guide builds on the [Sign-in With Solana Authentication](../authenticating-siws) guide to show how to use Lit Actions to generate PKP Session Signatures for an authorized Solana public key.

--- a/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
+++ b/docs/sdk/authentication/session-sigs/siws-pkp-session-sigs.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Using a Sign-in With Solana Message
 
 :::warning
-Instead of manually caching Session Signatures, please generate them on-demand.
+Please do not cache session signatures, and instead generate them on-demand.
 :::
 
 This guide builds on the [Sign-in With Solana Authentication](../authenticating-siws) guide to show how to use Lit Actions to generate PKP Session Signatures for an authorized Solana public key.


### PR DESCRIPTION
Added the below warning to the Session Signatures intro and generation pages:

![image](https://github.com/user-attachments/assets/7708d17a-cced-4e6c-a970-c48eb5129c1b)

