### PR TITLE
Update making-first-signing.md

### DIFF
--- a/docs/intro/first-request/making-first-signing.md
+++ b/docs/intro/first-request/making-first-signing.md
@@ -20,7 +20,7 @@ For more in-depth guides on PKP signing, please see the [PKPs](../../user-wallet
 
 ## Installing the Example Dependencies
 
-To start PKP signing with theLit SDK, you'll need to install these packages:
+To start PKP signing with the Lit SDK, you'll need to install these packages:
 
 - `@lit-protocol/lit-node-client`: The core Lit SDK package.
 - `@lit-protocol/constants`: A package containing useful constants across the SDK.


### PR DESCRIPTION
Update with space

At the Making [Your First Signing Request docs page](https://developer.litprotocol.com/intro/first-request/making-first-signing) there is space missing which seems confusing update this with the space.

![image](https://github.com/user-attachments/assets/f909e84c-f3a6-41b6-bace-bd7fca2309a5)

