### PR TITLE
compressing removed from sdk on v7, replaced with uint8array method

### DIFF
--- a/docs/integrations/storage/irys.md
+++ b/docs/integrations/storage/irys.md
@@ -180,6 +180,8 @@ For more advanced examples, see [unified access control conditions](https://deve
 We provide multiple methods to encrypt data, including strings, files, zip files.
 
 - `encryptString():` Encrypts a string.
+- `encryptFile()`: Encrypts a file. 
+- `encryptUint8Array()`: Encrypts a Uint8Array, which can be a compressed file. 
 - `encryptToJson()`: Encrypts a string or file and serializes the result to JSON. 
 
 We will use `encryptString()` to encrypt a simple string:
@@ -426,8 +428,10 @@ For more advanced examples, see [unified access control conditions](https://deve
 
 We provide multiple methods to encrypt data, including strings, files, zip files.
 
-- `encryptString()`: Encrypts a string.
-- `encryptToJson()`: Encrypts a string or file and serializes the result to JSON. 
+- `encryptString():` Encrypts a string.
+- `encryptFile()`: Encrypts a file.
+- `encryptUint8Array()`: Encrypts a Uint8Array, which can be a compressed file.
+- `encryptToJson()`: Encrypts a string or file and serializes the result to JSON.
 
 We will use `encryptString()` to encrypt a string:
 

--- a/docs/sdk/access-control/encryption.md
+++ b/docs/sdk/access-control/encryption.md
@@ -198,7 +198,7 @@ const accessControlConditions = [
 
 #### Encryption
 
-To encrypt a string, use one of the following functions:
+To encrypt a string, use:
 
 - [encryptString()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptString.html) - Used to encrypt the raw string.
 
@@ -206,7 +206,11 @@ To encrypt a file, use:
 
 - [encryptFile()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptFile.html) - Used to encrypt a file without doing any zipping or packing. Because zipping larger files takes time, this function is useful when encrypting large files ( > 20mb). This also requires that you store the file metadata.
 
-Apart from this, we have one more function which can be used to encrypt both strings and files:
+To encrypt a Uint8Array, use:
+
+- [encryptUint8Array()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptUint8Array.html) - Used to encrypt a Uint8Array, which can be the output of a [compression algorithm](https://github.com/LIT-Protocol/compression) or anything else that does not adhere to the string or file types.
+
+Apart from those, we have one more function which can be used to encrypt both strings and files:
 
 - [encryptToJson()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptToJson.html) - Used to encrypt a string or file and serialize all the metadata required to decrypt i.e. accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions & chain to JSON. It is useful for encrypting/decrypting data in IPFS or other storage without compressing it in a ZIP file.
 
@@ -523,6 +527,7 @@ To decrypt use the following functions depending on the function used to encrypt
 
 - [decryptToString()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.decryptToString.html) for [encryptString()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptString.html)
 - [decryptToFile()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.decryptToFile.html) for [encryptFile()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptFile.html)
+- [decryptToUint8Array()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.decryptToUint8Array.html) for [encryptUint8Array()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptUint8Array.html)
 - [decryptFromJson()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.decryptFromJson.html) for [encryptToJson()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptToJson.html)
 
 In the example, we used `encryptString()` to encrypt so we will use `decryptToString()` to decrypt. Pass in the data  `accessControlConditions`, `ciphertext`, `dataToEncryptHash`, and `authSig`.

--- a/docs/sdk/access-control/quick-start.md
+++ b/docs/sdk/access-control/quick-start.md
@@ -185,7 +185,7 @@ const accessControlConditions = [
 
 ### Encryption
 
-To encrypt a string, use the following function:
+To encrypt a string, use:
 
 - [encryptString()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptString.html) - Used to encrypt the raw string.
 
@@ -193,9 +193,13 @@ To encrypt a file, use:
 
 - [encryptFile()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptFile.html) - Used to encrypt a file without doing any zipping or packing. Because zipping larger files takes time, this function is useful when encrypting large files ( > 20mb). This also requires that you store the file metadata.
 
-Apart from these, we have one more function which can be used to encrypt both strings and files:
+To encrypt a Uint8Array, use:
 
-- [encryptToJson()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptToJson.html) - Used to encrypt a string or file and serialise all the metadata required to decrypt i.e. accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions & chain to JSON. It is useful for encrypting/decrypting data in IPFS or other storage without compressing it in a ZIP file.
+- [encryptUint8Array()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptUint8Array.html) - Used to encrypt a Uint8Array, which can be the output of a [compression algorithm](https://github.com/LIT-Protocol/compression) or anything else that does not adhere to the string or file types.
+
+Apart from those, we have one more function which can be used to encrypt both strings and files:
+
+- [encryptToJson()](https://v7-api-doc-lit-js-sdk.vercel.app/functions/encryption_src.encryptToJson.html) - Used to encrypt a string or file and serialize all the metadata required to decrypt i.e. accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions & chain to JSON. It is useful for encrypting/decrypting data in IPFS or other storage without compressing it in a ZIP file.
 
 Encryption can be performed entirely client-side and doesn't require making a request to the Lit nodes.
 


### PR DESCRIPTION
# Description

This PR is a demo on how SDK consumers can [de]compress the data they encrypted with Lit
Compression using JsZip was removed from the SDK on v7 [PR#621](https://github.com/LIT-Protocol/js-sdk/pull/621) so it now requires this extra code outside the SDK, but also allows customer to use their custom compression strategy

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added the following demo scripts in [LIT-Protocol/compression PR#1](https://github.com/LIT-Protocol/compression/pull/1) using jszip inside a zipper
```
  "scripts": {
    "run:zipAndEncryptString": "tsx ./src/zipAndEncryptString.ts",
    "run:zipAndEncryptMultipleFiles": "tsx ./src/zipAndEncryptMultipleFiles.ts",
    "run:zipFileAndBundleWithMetadata": "tsx ./src/zipFileAndBundleWithMetadata.ts"
  },
```

![Screenshot from 2025-01-06 13-23-34](https://github.com/user-attachments/assets/81299ba7-bad1-499b-8f21-927cf3668b1a)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation in [PR#395](https://github.com/LIT-Protocol/docs/pull/395)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
