### PR TITLE
Update connecting.md

### DIFF
--- a/docs/connecting-to-a-lit-network/connecting.md
+++ b/docs/connecting-to-a-lit-network/connecting.md
@@ -16,7 +16,7 @@ await litNodeClient.connect();
 ## Available Lit Networks
 
 :::warning
-With the release of [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) and the Datil networks, the [Chronicle](./lit-blockchains/chronicle) based Lit networks: `habanero`, `manzano`, and `cayenne` are going to be deprecated.
+With the release of [Chronicle Yellowstone](./lit-blockchains/chronicle-yellowstone) and the Datil networks, the [Chronicle](./lit-blockchains/chronicle) based Lit networks: `habanero`, `manzano`, and `cayenne` have been deprecated.
 
 If you are currently using these networks, please review the [Migrating to Datil](./migrating-to-datil) guide to migrate your application and Lit assets to a Datil network.
 :::
@@ -26,7 +26,7 @@ If you are currently using these networks, please review the [Migrating to Datil
 | Name       | Lit SDK Network Identifier | Doc Page Link                | Network is Live           |
 |------------|----------------------------|------------------------------|---------------------------|
 | Datil | `datil`               | [Link](./mainnets#datil)| ✅                        |
-| Habanero   | `habanero`                 | n/a                          | ⚠️ Going to be deprecated |
+| Habanero   | `habanero`                 | n/a                          | ⚠️ Deprecated |
 
 ### Testnets
 
@@ -34,5 +34,5 @@ If you are currently using these networks, please review the [Migrating to Datil
 |------------|----------------------------|-------------------------------|---------------------------|
 | Datil-test | `datil-test`               | [Link](./testnets#datil-test) | ✅                        |
 | Datil-dev  | `datil-dev`                | [Link](./testnets#datil-dev)  | ✅                        |
-| Manzano    | `manzano`                  | n/a                           | ⚠️ Going to be deprecated |
-| Cayenne    | `cayenne`                  | n/a                           | ⚠️ Going to be deprecated |
+| Manzano    | `manzano`                  | n/a                           | ⚠️ Deprecated |
+| Cayenne    | `cayenne`                  | n/a                           | ⚠️ Deprecated |


### PR DESCRIPTION
This fix marks the Habanero, Manzano, and Cayenne networks as deprecated. 