### PR TITLE
Doc links not working for signTransactionWithEthereumEncryptedKey and signTransactionWithSolanaEncryptedKey

### DIFF
--- a/docs/user-wallets/wrapped-keys/sign-transaction.md
+++ b/docs/user-wallets/wrapped-keys/sign-transaction.md
@@ -14,8 +14,8 @@ Below we will walk through an implementation of `signTransactionWithEncryptedKey
 1. The Wrapped Keys SDK will use the provided Wrapped Key ID and PKP Session Signatures to fetch the encryption metadata for a specific Wrapped Key
 2. Using the PKP Session Signatures, the SDK will make a request to the Lit network to execute the Sign Transaction Lit Action
    - Depending on the provided `network`, one of the following Lit Actions will be executed:
-     - If `network` is `ethereum`, then the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js) Lit Action is executed
-     - If `network` is `solana`, then the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js) Lit Action is executed
+     - If `network` is `ethereum`, then the [signTransactionWithEthereumEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys-lit-actions/src/lib/raw-action-functions/ethereum/signTransactionWithEncryptedEthereumKey.ts) Lit Action is executed
+     - If `network` is `solana`, then the [signTransactionWithSolanaEncryptedKey](https://github.com/LIT-Protocol/js-sdk/blob/master/packages/wrapped-keys-lit-actions/src/lib/raw-action-functions/solana/signTransactionWithEncryptedSolanaKey.ts) Lit Action is executed
 3. The Lit Action will verify the required transaction parameters were provided in order to sign the transaction
 4. The Lit Action will check the Access Control Conditions the plaintext private key was encrypted with to verify the PKP is authorized to decrypt the private key
 5. If authorized, the Wrapped Key will be decrypted within a Lit node's TEE. If not authorized, an error will be returned


### PR DESCRIPTION
Made changes to signTransactionWithEthereumEncryptedKey and signTransactionWithSolanaEncryptedKey links, should be working now.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes DREL - 388

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

General
- [ x] I have performed a self-review of my code
- [ x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [ x] I have checked the additions are concise
- [ x] Language is consistent with existing documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


If I have added a new concept, I have
- [ n/a] included a beginner friendly explanation
- [ n/a] included a basic technical introduction and code sample
- [n/a ] new terms are defined, both in relevant new pages and in the glossary

