### PR TITLE
Adjust docs for ethers recoverPublicKey prefixing the public key with 0x

### DIFF
--- a/docs/intro/first-request/making-first-signing.md
+++ b/docs/intro/first-request/making-first-signing.md
@@ -247,7 +247,8 @@ const recoveredAddress = ethers.utils.recoverAddress(
   encodedSig
 );
 
-console.log(recoveredPubkey === pkpInfo.publicKey); // true
+// adjust for ethers.utils.recoverPublicKey prefixing the public key with 0x
+console.log(recoveredPubkey === `0x${pkp.publicKey}`); // true
 console.log(recoveredAddress === pkpInfo.ethAddress); // true
 ```
 


### PR DESCRIPTION
# Description

Update "Signing Data" with PKP docs.`ethers.utils.recoverAddress` returns 0x${publicKey} (lit doesn't prefix with 0x in responses to mint/sign) so the assertion from docs (`recoveredPubkey === pkpInfo.publicKey`) fails.

Demo: https://stackblitz.com/edit/lit-pkp-signed-pubkey-mismatch-demo?file=src%2Fmain.ts

## Type of change

Documentation update

# Checklist:

General
- [x] I have performed a self-review of my code
- [x] I have fixed all grammar issues (can use an AI tool to check), and explanations are in active voice
- [x] I have checked the additions are concise
- [x] Language is consistent with existing documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (ie. SDK changes, node dependencies)


